### PR TITLE
Change the stylesheet implementation. It is now based on selectors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /node_modules/
 /log.log
+.project
+.settings

--- a/app/node_modules/modes/html/parser/grammar.pegjs
+++ b/app/node_modules/modes/html/parser/grammar.pegjs
@@ -187,7 +187,6 @@ block = open:opening ws0:__ elements:(elementList __)? close:closing {
 opening = opening:openingOpening id:id ws0:__ attributes:(attributeList __)? closing:openingClosing {
 	var node = Node('opening', line(), column(), offset(), text());
 	node.add('opening', opening);
-	id.type.element = 'opening-id'; // Quick & dirty, for tests
 	node.add('id', id);
 	node.addList('spaces.0', ws0);
 	if (attributes !== "") {
@@ -229,7 +228,6 @@ closingClosing = ">" {
 
 attribute = key:id value:(__ attributeAssignementOperator __ attrvalue)? {
 	var node = Node('attribute', line(), column(), offset(), text());
-	key.type.element = 'attribute-id'; // Quick & dirty, for tests
 	node.add('key', key);
 	if (value !== "") {
 		node.addList('spaces.0', value[0]);

--- a/app/node_modules/modes/html/stylesheet.js
+++ b/app/node_modules/modes/html/stylesheet.js
@@ -32,7 +32,7 @@ var stylesheet = factory({
 			color: 'blue'
 		},
 
-		'attribute-id': {
+		'attribute.id': {
 			color: 'red'
 		},
 		'string': {

--- a/app/node_modules/modes/node_modules/highlight/stylesheet.js
+++ b/app/node_modules/modes/node_modules/highlight/stylesheet.js
@@ -13,7 +13,14 @@ var Stylesheet = oop.Class({
 
 	constructor: function() {
 		this.styles = {};
+		this._styleRegExps = {};
+		this._sortedSelectors = null;
 		this.default = undefined;
+	},
+
+	statics: {
+		CLASS_PREFIX: "editor-highlight-",
+		DEFAULT_CLASS: "token"
 	},
 
 	methods: {
@@ -21,27 +28,54 @@ var Stylesheet = oop.Class({
 			input: {
 				properties: [
 					{name: 'style', type: Style, mixed: true},
-					{names: ['id', 'key']}
+					{names: ['selector', 'id', 'key']}
 				]
 			},
 
 			process: function(spec) {
-				if (spec.id == null) {
+				if (spec.selector == null) {
 					this['default'] = spec.style;
 				} else {
-					this.styles[spec.id] = spec.style;
+					this.styles[spec.selector] = spec.style;
+					this._styleRegExps[spec.selector] = new RegExp("(\\.|^)" + spec.selector.replace(/\./g, "\\.") + "$");
 				}
+				this._sortedSelectors = Object.keys(this.styles).sort(function (a, b) {
+					var revA = a.split("").reverse().join("");
+					var revB = b.split("").reverse().join("");
+					if (revA > revB) {
+						return -1;
+					}
+					if (revA == revB) {
+						return 0;
+					}
+					return 1;
+				});
 			},
 
 			output: 'style'
 		},
 
 		/**
-		 * Returns the list of defined styles.
+		 * Convert a selector into a valid classname
 		 */
-		stylesNames: function() {
-			return Object.keys(this.styles);
+		convertSelectorToClassName: function(selector) {
+			return selector.replace(/\./g, "-");
 		},
+
+		/**
+		 * Returns the classname to apply for a certain fullpath
+		 */
+		 getStyleFromPath : function(fullpath) {
+		 	var selector;
+		 	for (var i = 0, length = this._sortedSelectors.length; i < length; i++) {
+		 		selector = this._sortedSelectors[i];
+		 		if (fullpath.match(this._styleRegExps[selector])) {
+		 			return selector;
+		 		}
+		 	}
+		 	return null;
+		 },
+
 
 		/***********************************************************************
 		 * Serialization
@@ -52,11 +86,11 @@ var Stylesheet = oop.Class({
 		 */
 		css: function() {
 			var ruleSets = [];
-			ruleSets.push(".editor-highlight-token {" + this.default.css().join(';') + "}");
+			ruleSets.push("." +  Stylesheet.CLASS_PREFIX + Stylesheet.DEFAULT_CLASS + "{" + this.default.css().join(';') + "}");
 			for (var selector in this.styles) {
 				var style = this.styles[selector];
 				var declarations = style.css();
-				ruleSets.push('.editor-highlight-' + selector + ' {' + declarations.join(';') + '}');
+				ruleSets.push('.' + Stylesheet.CLASS_PREFIX + this.convertSelectorToClassName(selector) + ' {' + declarations.join(';') + '}');
 			}
 			return ruleSets.join('\n');
 		},

--- a/app/node_modules/modes/node_modules/mode.js
+++ b/app/node_modules/modes/node_modules/mode.js
@@ -49,8 +49,6 @@ var Mode = oop.Class({
 				parser: this.parser
 			});
 		}
-
-		this.highlightedNodes = this.highlightDefaultStyleNodes.concat(this._stylesheet.stylesNames());
 	},
 
 
@@ -160,9 +158,9 @@ var Mode = oop.Class({
 
 				var style = '';
 				if (range.style != '') {
-					style = ' editor-highlight-' + range.style;
+					style = Stylesheet.CLASS_PREFIX + this._stylesheet.convertSelectorToClassName(range.style);
 				}
-				output += "<span class='editor-highlight-token" + style + "'>" + str + "</span>";
+				output += "<span class='" + Stylesheet.CLASS_PREFIX + Stylesheet.DEFAULT_CLASS + " " + style + "'>" + str + "</span>";
 			}
 
 			return output;
@@ -183,61 +181,30 @@ var Mode = oop.Class({
 
 			// Marks -----------------------------------------------------------
 
-			var highlightedNodes = this.highlightedNodes;
-
-			graph.traverse(function(node) {
-				if (highlightedNodes.indexOf(node.type.element) !== -1) {
-					node.highlight = {
-						style: node.type.element
-					}
-				}
-			});
-
-			// For development -------------------------------------------------
-
-			// Checks that every branch of the graph has a highlight mark, so that we will end with the whole source code highlighted
-
-			if (false) {
-				var branches = graph.branches();
-				for (var i = 0, length = branches.length; i < length; i++) {
-					var branch = branches[i];
-					var branchOK = false;
-					for (var j = 0, length2 = branch.length; j < length2; j++) {
-						var fragment = branch[j];
-						if (fragment.highlight != null) {
-							branchOK = true;
-							break;
-						}
-					}
-					if (!branchOK) {
-						throw {
-							msg: 'A branch is not marked for highlighting',
-							number: i + 1,
-							branch: prelude.map(function(node) {
-								return {
-									src: node.source,
-									type: node.type.element
-								}
-							}, branch)
-						}
-					}
-				}
+			var fakeParent = false;
+			if (graph.parent == null) {
+				fakeParent = true;
+				graph.parent = {
+					fullpath: graph.type.element
+				};
 			}
 
-			// Sinks -----------------------------------------------------------
-
-			// Gets marks from parents and put them into their children, to have all leaves marked, even if their marks have style corresponding to some ancestor nodes' types.
+			var stylesheet = this._stylesheet;
+			// Compute marks based on the node fullpath, and, if none is applicable, get marks from parents and put them into their children, to have all leaves marked, even if their marks have style corresponding to some ancestor nodes' types.
 
 			graph.traverse(function(node) {
-				if (node.highlight != null) {
-					for (var i = 0, length = node.children.length; i < length; i++) {
-						var child = node.children[i];
-						if (child.highlight == null) {
-							child.highlight = node.highlight;
-						}
-					}
-				}
+				var fullpath = node.parent.fullpath + "." + node.type.element;
+				node.fullpath = fullpath;
+				var style = stylesheet.getStyleFromPath(fullpath);
+				node.highlight = style != null ? {
+					style: style
+				} : node.parent.highlight;
 			});
+
+
+			if (fakeParent) {
+				delete graph.parent;
+ 			}
 
 			// Transforms ------------------------------------------------------
 


### PR DESCRIPTION
Mode:
- change in the way style for a node is computed. Introduction of a fullpath property in nodes that is needed by the style assignment algorithm.
- removal of a graph traversal operation that was needed to mark unmarked nodes. It is now included in the first vtraversal that takes care of marking markable nodes.
- removal of hardcoded default css classNames.

Stylesheet
- change in the way styles are associated to a node. It is now based on fullpaths. You can now define styles that apply to an certain path. For example, if you want id's in attributes to have a certain style, you can add a rule for 'attribute.id'. You can also add more specific rules by using a path. The most precise one will be chosen for a certain node.

HTML Grammar:
- removed the parent dependent element type (used for distinguishing id's present in the opening tag or in an attribute).

Gitignore
- the main .gitignore file hasbeen changed so that eclipse-specific project files are ignored.
