### PR TITLE
Added several enhancements for development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,40 @@ Also, [build the HTML parser](app/node_modules/modes/html/parser#setup).
 * execute the command: `npm start` from this directory
 * (you can check it works if [this](http://localhost:3000/ping) sends `OK`)
 
+## Test
+
+You can also run the set of tests, and you __MUST DO IT__ when you develop, before requesting any integration of your work.
+
+For that, simply run the npm script:
+
+```bash
+npm test
+```
+
+## Development utilities
+
+To avoid rebuilding the grammars manually anytime you change them, or any other file that needs to be rebuilt, you can use the provided watch script. Run it from the root of the package, like this:
+
+```bash
+npm run-script watch
+```
+
+However, for now it doesn't handle restarting the whole application (the server) when a change is made in its code, because this is a bit heavy and requires some subtle logic to keep it handy.
+
+But you can use the _native_ npm script to restart the application:
+
+```bash
+npm restart
+```
+
+This is possible due to the fact that a `stop` script has been added in addition to the `start` one. So you can also do:
+
+```bash
+npm stop
+```
+
+to shut the server down, instead of using a kill signal.
+
 ## Development
 
 Please refer to the subfolders of the project for details about corresponding modules specific development: every folder containing a documentation like this contains a section talking about contributions you can make to it.

--- a/app/node_modules/modes/html/parser/README.md
+++ b/app/node_modules/modes/html/parser/README.md
@@ -35,13 +35,11 @@ To version: _everything else_.
 
 ## Setup
 
-To be able to use the parser, build the grammar with the following command executed from this folder: `..\..\..\..\..\node_modules\.bin\pegjs --extra-options-file options.json grammar.pegjs`.
+To be able to use the parser, build the grammar. A npm script is available for that, just launch this command from the [root of the package](/):
 
-This command uses a binary installed by npm, in the `node_modules` folder dedicated to third-parties libraries (in [the root folder](/) of the backend project). If it doesn't work, maybe the PEG.js module was not properly installed, try reinstalling it.
-
-Optionally you can add the installed PEG.js binary to your system environment variable `PATH`, and then simply use the command: `pegjs --extra-options-file options.json grammar.pegjs`, which avoids the path mess.
-
-Alternatively, you can also manually install PEG.js globally, with the good version, using the following command: `npm install -g git+https://github.com/dmajda/pegjs`.
+```bash
+npm run-script build
+```
 
 ## Try
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,12 @@
 
 
 	"scripts": {
-		"start": "node app/index.js"
+		"build": "node scripts/build.js",
+		"start": "node app/index.js",
+		"stop": "node scripts/shutdown.js",
+
+		"watch": "node scripts/watch.js",
+		"test": "mocha"
 	},
 	"bin": {
 		"editor-svc": "app/index.js"
@@ -53,13 +58,17 @@
 	"engines": {
 		"node": "*"
 	},
+	"devDependencies": {
+		"chokidar": "*",
+		"mocha": "*"
+	},
 	"dependencies": {
 		"lodash": "*",
 		"prelude-ls": "*",
 
 		"oop": "git+https://github.com/ymeine/oop",
 
-		"http-server": "git+https://github.com/ymeine/http-server",
+		"http-server": "git+https://github.com/Kykstudio/http-server",
 		"winston": "*",
 
 		"pegjs": "git+https://github.com/dmajda/pegjs",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,4 @@
+var grammarBuilder = require('./grammar-builder');
+
+grammarBuilder.build('html');
+grammarBuilder.build('at');

--- a/scripts/grammar-builder.js
+++ b/scripts/grammar-builder.js
@@ -1,0 +1,19 @@
+var fs = require('fs');
+
+var peg = require('pegjs');
+
+
+
+function build(name) {
+	var basePath = 'app/node_modules/modes/' + name + '/parser/';
+	var options = require('../' + basePath + 'options');
+	var grammar = fs.readFileSync(basePath + 'grammar.pegjs', 'utf-8');
+
+	options.output = 'source';
+	var source = peg.buildParser(grammar, options);
+
+	fs.writeFileSync(basePath + 'grammar.js', 'module.exports = ' + source);
+}
+
+
+exports.build = build;

--- a/scripts/shutdown.js
+++ b/scripts/shutdown.js
@@ -1,0 +1,7 @@
+var http = require('http');
+
+http.get('http://localhost:3000/shutdown', function(response) {
+	console.log("Status: " + response.statusCode);
+}).on('error', function(error) {
+	console.error("Error: " + error.message);
+});

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -1,0 +1,19 @@
+var chokidar = require('chokidar');
+
+var grammarBuilder = require('./grammar-builder');
+
+function createWatcher(grammar) {
+	var watcher = chokidar.watch('app/node_modules/modes/' + grammar + '/parser/grammar.pegjs', {
+		persistent: true
+	});
+
+	watcher.on('change', function(path) {
+		grammarBuilder.build(grammar);
+	});
+
+	return watcher;
+}
+
+createWatcher('html');
+createWatcher('at');
+


### PR DESCRIPTION
These features are mainly accessible from the npm scripts feature.

Here they are:
- watch: you can now launch a watch process to rebuild your grammars anytime you change them (closes #20)
- test: launches the tests with mocha
- build: builds the package. Actually only build the grammars for now.
- stop: sends the shutdown signal to the server

Documentation has been updated accordingly.

NB: for now grammars handled by the build and watch scripts are HTML and AT. But it's easy to add others by appending them in corresponding scripts.
