### PR TITLE
Mainly fixed and completed the AT grammar.

### DIFF
--- a/app/node_modules/modes/at/parser/README.md
+++ b/app/node_modules/modes/at/parser/README.md
@@ -31,11 +31,17 @@ To version: _everything else_.
 
 ## Setup
 
-To be able to use the parser, build the grammar with the following command:
+To be able to use the parser, build the grammar with the following command executed from this folder:
 
-```dos
-call ..\..\..\..\..\node_modules\.bin\pegjs --extra-options-file options.json grammar.pegjs
+```bash
+..\..\..\..\..\node_modules\.bin\pegjs --extra-options-file options.json grammar.pegjs
 ```
+
+This command uses a binary installed by npm, in the `node_modules` folder dedicated to third-parties libraries (in [the root folder](/) of the backend project). If it doesn't work, maybe the PEG.js module was not properly installed, try reinstalling it.
+
+Optionally you can add the installed PEG.js binary to your system environment variable `PATH`, and then simply use the command: `pegjs --extra-options-file options.json grammar.pegjs`, which avoids the path mess.
+
+Alternatively, you can also manually install PEG.js globally, with the good version, using the following command: `npm install -g git+https://github.com/dmajda/pegjs`.
 
 ## Try
 

--- a/app/node_modules/modes/at/parser/grammar.pegjs
+++ b/app/node_modules/modes/at/parser/grammar.pegjs
@@ -4,6 +4,18 @@
 	var lib = require('pegjs-parser/initializer');
 
 	var Node = new lib.NodeInstancier('at');
+
+	var blocks = [
+		'cdata',
+		'text',
+		'block'
+	];
+
+	Node.addHook(function(node) {
+		if (blocks.indexOf(node.type.element) >= 0) {
+			node.flag('block');
+		}
+	});
 }
 
 
@@ -12,33 +24,39 @@
 
 // ------------------------------------------------------------------------ Root
 
-start = ws0:__ elements:(elementList __)? {
+start = ws0:__ nodes:(nodeList __)? {
 	var node = Node('root', line(), column(), offset(), text());
+
 	node.addList('spaces.0', ws0);
-	if (elements !== "") {
-		node.addList('elements', elements[0]);
-		node.addList('spaces.1', elements[1]);
+
+	if (nodes !== "") {
+		node.addList('nodes', nodes[0]);
+		node.addList('spaces.1', nodes[1]);
 	}
+
 	return node;
 }
 
-// -------------------------------------------------------------------- Elements
+// ----------------------------------------------------------------------- Nodes
 
-element =
+node =
 	text
 	/ statement
 
-elementList = head:element rest:(__ element)* {
+// FIXME This rule is used to parse a list of nodes contained in a block element (most of the time)
+// These nodes are a mix of text, statements, and comments also.
+// However, concerning the comments, they are "eaten" by the "__" rule, whose content is skipped here.
+// So concretely if a node contains only text except some content inside, these comments are ignored because of that.
+// Review the design of this rule
+nodeList = head:node rest:(__ node)* {
 	return lib.listFromSequence(head, rest);
 }
 
 // ------------------------------------------------------------------------ Text
-// The particularity of the text element, is that it is not delimited as other elements, it's just everything that is not an element. So to detect the end of a text, we need to check if another element starts.
+// The particularity of the text node, is that it is not delimited as other nodes - that is elements, it's just everything that is not an element. So to detect the end of a text, we need to check if an element starts.
 
 text = content:$(!statementStart .)+ {
-	var node = Node(null, line(), column(), offset(), text());
-	node.set('value', content);
-	return node;
+	return Node('text', line(), column(), offset(), text());
 }
 
 statementStart = "${" / "{" / "/*" / "//"
@@ -47,128 +65,258 @@ statementStart = "${" / "{" / "/*" / "//"
 // WARNING the precedence in alternatives is important!
 
 statement =
-	expression
+	cdata
+	/ expression
 	/ inline
-	/ cdata
 	/ block
-
-// ------------------------------------------------------------------ Expression
-
-expression = "${" ws0:__ param:blockStatementParam? ws1:__ "}" {
-	var node = Node('expression', line(), column(), offset(), text());
-	node.addList('spaces.0', ws0);
-	node.set('param', param);
-	node.addList('spaces.1', ws1);
-	return node;
-}
-
-// TODO The following is a work in progress and is not actually used for now
-
-expressionContent = value:expressionValue? parameters:(expressionParameter)* {
-
-}
-expressionValue = $(!"|" .)+
-expressionParameter = value:expressionParameterValue args:(":" expressionParameterArg)? {
-
-}
-expressionParameterValue = $(!":" .)+
-// TODO Split args with commas?
-expressionParameterArg = $(!"|" .)+
-
-// ---------------------------------------------------------------------- Inline
-
-inline = "{" __ id:tagId param:(ws inlineStatementParam)? "/}" {
-	var node = Node('inline', line(), column(), offset(), text());
-	node.add('id', id);
-	node.set('param', param[1] || "");
-	return node;
-}
-
-inlineStatementParam = $(!"/}" bracedContent)*
 
 // ----------------------------------------------------------------------- CDATA
 
-cdata = "{" ws0:__ "CDATA" ws1:__ "}" content:$(!endOfCdata .)* endOfCdata {
-	var node = Node('cdata', line(), column(), offset(), text())
-	node.addList('spaces.0', ws0);
-	node.addList('spaces.1', ws1);
-	node.set('content', content);
+cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing {
+	var node = Node('cdata', line(), column(), offset(), text());
+
+	node.add('opening', opening);
+
+	if (content != "") {
+		node.add('content', content);
+	}
+
+	node.add('closing', closing);
+
 	return node;
 }
 
-endOfCdata = "{/" __ "CDATA" __"}"
+cdataOpening = opening:cdataOpeningOpening ws0:__ closing:cdataOpeningClosing {
+	var node = Node('opening', line(), column(), offset(), text());
+	node.add('opening', opening);
+	node.addList('spaces.0', ws0);
+	node.add('closing', closing);
+	return node;
+}
+
+cdataOpeningOpening = "{CDATA" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+cdataOpeningClosing = "}" {
+	return Node('closing', line(), column(), offset(), text());
+}
+
+cdataClosing = "{/CDATA}" {
+	return Node('closing', line(), column(), offset(), text());
+}
+
+cdataContent = (!cdataClosing .)+ {
+	return Node('content', line(), column(), offset(), text());
+}
+
+// ------------------------------------------------------------------ Expression
+
+expression = opening:expressionOpening ws0:__ content:expressionContent? ws1:__ closing:expressionClosing {
+	var node = Node('expression', line(), column(), offset(), text());
+
+	node.add('opening', opening);
+
+	node.addList('spaces.0', ws0);
+
+	if (content != "") {
+		node.add('param', content);
+	}
+
+	node.addList('spaces.1', ws1);
+
+	node.add('closing', closing);
+
+	return node;
+}
+
+expressionOpening = "${" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+expressionClosing = "}" {
+	return Node('closing', line(), column(), offset(), text());
+}
+
+// expressionContent = blockStatementParam
+
+// TODO The following is a work in progress and is not actually used for now
+
+expressionContent = value:expressionValue? modifiers:expressionModifierList? {
+	var node = Node('content', line(), column(), offset(), text());
+
+	if (value != "") {
+		node.add('value', value);
+	}
+
+	if (modifiers != "") {
+		node.addList('modifiers', modifiers);
+	}
+
+	return node;
+}
+
+expressionValue = (!expressionModifierPrefix .)+ {
+	return Node('text', line(), column(), offset(), text());
+}
+
+expressionModifierList = head:expressionModifier rest:(__ expressionModifier)* {
+	return lib.listFromSequence(head, rest);
+}
+
+expressionModifier = prefix:expressionModifierPrefix name:expressionModifierName param:expressionModifierParam? {
+	var node = Node('modifier', line(), column(), offset(), text());
+	node.add('prefix', prefix);
+	node.add('name', name);
+	if (param != "") {
+		node.add('param', param);
+	}
+	return node;
+}
+
+expressionModifierPrefix = "|" {
+	return Node('prefix', line(), column(), offset(), text());
+}
+
+expressionModifierName = id
+
+expressionModifierParam = prefix:expressionModifierParamPrefix value:expressionModifierParamValue? {
+	var node = Node('modifier-param', line(), column(), offset(), text());
+	node.add('prefix', prefix);
+	if (value != "") {
+		node.add('value', value);
+	}
+	return node;
+}
+
+expressionModifierParamPrefix = ":" {
+	return Node('prefix', line(), column(), offset(), text());
+}
+
+// TODO Split param with commas?
+expressionModifierParamValue = (!(expressionModifierPrefix / expressionClosing) .)+ {
+	return Node('text', line(), column(), offset(), text());
+}
+
+// ---------------------------------------------------------------------- Inline
+
+inline = opening:inlineOpening id:tagId param:inlineStatementParam? closing:inlineClosing {
+	var node = Node('inline', line(), column(), offset(), text());
+
+	node.add('opening', opening);
+	node.add('id', id);
+
+	if (param !== "") {
+		node.add('param', param);
+	}
+
+	node.add('closing', closing);
+
+	return node;
+}
+
+inlineOpening = "{" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+inlineClosing = "/}" {
+	return Node('closing', line(), column(), offset(), text());
+}
+
+inlineStatementParam = (!inlineClosing bracedContent)+ {
+	return Node('text', line(), column(), offset(), text());
+}
 
 // ----------------------------------------------------------------------- Block
 
-block = open:opening ws0:__ elements:(elementList __)? close:closing {
+block = open:opening ws0:__ nodes:(nodeList __)? close:closing {
 	var node = Node('block', line(), column(), offset(), text());
 	node.add('openTag', open);
 	node.addList('spaces.0', ws0);
-	if (elements !== "") {
-		node.addList('elements', elements[0]);
-		node.addList('spaces.1', elements[1]);
+	if (nodes !== "") {
+		node.addList('nodes', nodes[0]);
+		node.addList('spaces.1', nodes[1]);
 	}
 	node.add('closeTag', close);
 	return node;
 }
 
-opening = "{" ws0:__ id:tagId param:(ws blockStatementParam)? "}" {
+opening = opening:openingOpening id:tagId param:blockStatementParam? closing:openingClosing {
 	var node = Node('opening', line(), column(), offset(), text());
-	node.addList('spaces.0', ws0);
+
+	node.add('opening', opening);
 	node.add('id', id);
+
 	if (param !== "") {
-		node.add('spaces.1', param[0]);
-		node.set('param', param[1]);
-	} else {
-		node.set('param', "");
+		node.add('param', param);
 	}
+
+	node.add('closing', closing);
+
 	return node;
 }
 
-blockStatementParam = $(!"}" bracedContent)*
+openingOpening = "{" {
+	return Node('opening', line(), column(), offset(), text());
+}
 
-closing = "{/" ws0:__ id:tagId ws1:__ "}" {
+openingClosing = "}" {
+	return Node('closing', line(), column(), offset(), text());
+}
+
+blockStatementParam = (!"}" bracedContent)+ {
+	return Node('text', line(), column(), offset(), text());
+}
+
+closing = opening:closingOpening id:tagId closing:closingClosing {
 	var node = Node('closing', line(), column(), offset(), text());
-	node.addList('spaces.0', ws0);
+	node.add('opening', opening);
 	node.add('id', id);
-	node.addList('spaces.1', ws1);
+	node.add('closing', closing);
 	return node;
 }
 
+closingOpening = "{/" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+closingClosing = "}" {
+	return Node('closing', line(), column(), offset(), text());
+}
 
 // ------------------------------------------------------------------------- Tag
 // FIXME Check the id specification
 
 tagId =
 	widgetId
-	/ standardId
+	/ id
 
-widgetId = "@" ns:id ":" widget:id {
+widgetId = prefix:widgetIdPrefix ns:id separator:widgetNamespaceWidgetSeparator widget:id {
 	var node = Node('widgetId', line(), column(), offset(), text());
-	node.set('namespace', ns);
-	node.set('widget', widget);
+	node.add('prefix', prefix);
+	node.add('namespace', ns);
+	node.add('separator', separator)
+	node.add('widget', widget);
 	return node;
 }
 
-standardId = id:id {
-	var node = Node('id', line(), column(), offset(), text());
-	node.set('value', id);
-	return node;
+widgetIdPrefix = "@" {
+	var node = Node('prefix', line(), column(), offset(), text());
+}
+
+widgetNamespaceWidgetSeparator = ":" {
+	var node = Node('separator', line(), column(), offset(), text());
 }
 
 // ----------------------------------------------------------------------- Param
 // FIXME There can be some }, depending on the context: JS Object, string, comment, ...
 
-braced = "{" content:bracedContent* "}" {
-	return "{" + content.join('') + "}"
-}
-
 bracedContent = braced / nonbraced
 
+braced = $("{" content:bracedContent* "}")
+
 nonbraced =
-	seq:("\\" ("{" / "}")) {
-		return seq.join('');
-	}
+	$("\\" ("{" / "}"))
 	/ [^{}]
 
 // -------------------------------------------------------------------- Comments
@@ -177,44 +325,81 @@ comment =
 	multiLineComment
 	/ singleLineComment
 
-multiLineComment = "/*" content:$(!"*/" .)* "*/" {
+multiLineComment = opening:multiLineCommentOpening content:multiLineCommentContent? closing:multiLineCommentClosing {
 	var node = Node('multi-line-comment', line(), column(), offset(), text());
-	node.set('value', content);
+
+	node.add('opening', opening);
+	if (content !== "") {
+		node.add('content', content);
+	}
+	node.add('closing', closing);
+
 	return node;
 }
 
-singleLineComment = "//" content:$(!eol .)* eol {
+multiLineCommentOpening = "/*" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+multiLineCommentClosing = "*/" {
+	return Node('closing', line(), column(), offset(), text());
+}
+
+multiLineCommentContent = (!multiLineCommentClosing .)+ {
+	return Node('content', line(), column(), offset(), text());
+}
+
+singleLineComment =  opening:singleLineCommentOpening content:singleLineCommentContent? closing:singleLineCommentClosing {
 	var node = Node('single-line-comment', line(), column(), offset(), text());
-	node.set('value', content);
+
+	node.add('opening', opening);
+	if (content !== "") {
+		node.add('content', content);
+	}
+	node.add('closing', closing);
+
 	return node;
+}
+
+singleLineCommentOpening = "//" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+singleLineCommentClosing = node:eol {
+	node.type.element = 'closing' // dirty hack
+	return node;
+}
+
+singleLineCommentContent = (!singleLineCommentClosing .)+ {
+	return Node('content', line(), column(), offset(), text());
 }
 
 // --------------------------------------------------------------------- Various
 
-__ = (wsSequence / comment)*
+__ = elements:(wsSequence / comment)* {
+	return elements;
+}
 
 // Primitives ------------------------------------------------------------------
 
 // -------------------------------------------------------------------------- ID
 
-id = start:idstart rest:idrest* {return start + rest.join('')}
-special = [$_]
-idchars = alpha / special
-idstart = idchars
-idrest = idchars / digit
+id = idhead idrest* {
+	return Node('id', line(), column(), offset(), text());
+}
+idhead = idchars
+idrest = digit / idchars
+idchars = alpha / idspecial
+idspecial = [_]
 
 // ---------------------------------------------------------------- White spaces
 
-ws = char:[ \r\n\t] {
-	var node = Node('ws', line(), column(), offset(), text());
-	node.set('char', char);
-	return node;
-}
+ws = [ \r\n\t]
 
 wsSequence =
 	spaces
 	/ tabs
-	/ eol
+	/ eols
 
 spaces = content:" "+ {
 	var node = Node('spaces', line(), column(), offset(), text());
@@ -228,7 +413,13 @@ tabs = content:"\t"+ {
 	return node;
 }
 
-eol = value:("\r\n" / "\r" / "\n") {
+eols = content:eol+ {
+	var node = Node('eols', line(), column(), offset(), text());
+	node.addList('eol', content);
+	return node;
+}
+
+eol = value:("\r\n" / "\n" / "\r") {
 	var node = Node('eol', line(), column(), offset(), text());
 	node.set('value', value);
 	return node;
@@ -238,26 +429,3 @@ eol = value:("\r\n" / "\r" / "\n") {
 
 alpha = [a-zA-Z]
 digit = [0-9]
-
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-// ----------------------------------------------------------------------- Tests
-
-// XXX Add a semantic dimension, like:
-// - it's the opening of a tag
-// - ...
-// In fact, only __ between terminals avoids computing the position of elements.
-
-openingCurlyBracket = "{" {
-	var node = Node('token.bracket.curly.opening', line(), column(), offset(), text());
-	node.set('char', '\u007B'); // Hack to conform to PEG.js syntax
-	return node;
-}
-
-
-closingCurlyBracket = "}" {
-	var node = Node('token.bracket.curly.closing', line(), column(), offset(), text());
-	node.set('char', '\u007D'); // Hack to conform to PEG.js syntax
-	return node;
-}
-

--- a/app/node_modules/modes/at/parser/test.tpl
+++ b/app/node_modules/modes/at/parser/test.tpl
@@ -1,6 +1,6 @@
 
 {Template {
-    $other: "Main\}"
+    $other: "Main\}",
     $classpath: "Main\{"
 }}
 
@@ -9,7 +9,7 @@
 
         {call a() /}
         /*<div>/*Comment*///</d//iv>
-        ${exp|arg:value}
+        ${exp|modifier1:arg11|modifier2:arg21, arg22}
         {CDATA}
             {Template}
             <div>


### PR DESCRIPTION
- updated the AT parser documentation
- fixed a little the test input for the parser

AT Grammar:
- block nodes are now flagged as "block"
- changed term "element" to "node": more generic, and consistent with HTML
- some unnecessary code/rules have been removed
- changed some precedence in rules for better accuracy and consistency too
- completed the terminals encapsulation in nodes for many rules
- fixed CDATA content parsing (made it optional)
- finished implementing the parsing of expressions (with modifiers)
- fixed some little quirks (like allowing spaces at wrong places, setting properties with nodes, ...)
