### PR TITLE
Fixed the HTML grammar (& made it more consistent).

### DIFF
--- a/app/node_modules/modes/html/parser/README.md
+++ b/app/node_modules/modes/html/parser/README.md
@@ -7,7 +7,7 @@ However, having our own parser, even if it would need to be maintained by us, al
 # File system layout
 
 * [`README.md`](./README.md): this current file
-* `.gitignore`: Git related file
+* [`.gitignore`](./.gitignore): Git related file
 
 Parser:
 

--- a/app/node_modules/modes/html/parser/grammar.pegjs
+++ b/app/node_modules/modes/html/parser/grammar.pegjs
@@ -24,79 +24,112 @@
 
 // ------------------------------------------------------------------------ Root
 
-start = ws0:__ elements:(elementList __)? {
+start = ws0:__ nodes:(nodeList __)? {
 	var node = Node('root', line(), column(), offset(), text());
 
 	node.addList('spaces.0', ws0);
 
-	if (elements !== "") {
-		node.addList('elements', elements[0]);
-		node.addList('spaces.1', elements[1]);
+	if (nodes !== "") {
+		node.addList('nodes', nodes[0]);
+		node.addList('spaces.1', nodes[1]);
 	}
 
 	return node;
 }
 
-// -------------------------------------------------------------------- Elements
+// ----------------------------------------------------------------------- Nodes
 
-element =
+node =
 	text
-	/ node
+	/ element
 
-// FIXME This rule is used to parse a list of elements contained in a block element (most of the time)
-// These elements are a mix of text, node, and comments also.
+// FIXME This rule is used to parse a list of nodes contained in a block element (most of the time)
+// These nodes are a mix of text, elements, and comments also.
 // However, concerning the comments, they are "eaten" by the "__" rule, whose content is skipped here.
-// So concretely if a node contains only text except some contents inside, these comments are ignored because of that.
-// Review the design of this rule (should be the same for Aria Templates grammar)
-elementList = head:element rest:(__ element)* {
+// So concretely if a node contains only text except some content inside, these comments are ignored because of that.
+// Review the design of this rule
+nodeList = head:node rest:(__ node)* {
 	return lib.listFromSequence(head, rest);
 }
 
 // ------------------------------------------------------------------------ Text
-// The particularity of the text element, is that it is not delimited as other elements, it's just everything that is not an element. So to detect the end of a text, we need to check if another element starts.
+// The particularity of the text node, is that it is not delimited as other nodes - that is elements, it's just everything that is not an element. So to detect the end of a text, we need to check if an element starts.
 
 text = content:$(!elementStart .)+ {
-	var node = Node('text', line(), column(), offset(), text());
-	return node;
+	return Node('text', line(), column(), offset(), text());
 }
 
 elementStart = "<"
 
-// ----------------------------------------------------------------------- Nodes
+// -------------------------------------------------------------------- Elements
 // WARNING the precedence in alternatives is important!
 
-node =
+element =
 	cdata
 	/ directive
 	/ inline
 	/ block
 
+// ----------------------------------------------------------------------- CDATA
+
+cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing {
+	var node = Node('cdata', line(), column(), offset(), text());
+
+	node.add('opening', opening);
+
+	if (content !== "") {
+		node.add('content', content);
+	}
+
+	node.add('closing', closing);
+
+	return node;
+}
+
+cdataOpening = "<![CDATA[" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+cdataClosing = "]]>" {
+	return Node('closing', line(), column(), offset(), text());
+}
+
+cdataContent = (!cdataClosing .)+ {
+	return Node('content', line(), column(), offset(), text());
+}
+
 // ------------------------------------------------------------------- Directive
 
-directive = opening:directiveOpening ws0:__ id:id ws1:__ content:directiveContent closing:directiveClosing {
+directive = opening:directiveOpening ws0:__ id:id ws1:__ content:directiveContent? closing:directiveClosing {
 	var node = Node('directive', line(), column(), offset(), text())
 
 	node.add('opening', opening);
+
 	node.addList('spaces.0', ws0);
+
 	node.add('id', id);
+
 	node.addList('spaces.1', ws1);
-	node.add('content', content);
+
+	if (content !== "") {
+		node.add('content', content);
+	}
+
 	node.add('closing', closing);
 
 	return node;
 }
 
 directiveOpening = "<!" {
-	return Node('directive.opening', line(), column(), offset(), text());
+	return Node('opening', line(), column(), offset(), text());
 }
 
 directiveClosing = ">" {
-	return Node('directive.closing', line(), column(), offset(), text());
+	return Node('closing', line(), column(), offset(), text());
 }
 
-directiveContent = (!">" .)* {
+directiveContent = (!">" .)+ {
 	var node = Node('text', line(), column(), offset(), text());
-	// node.set('content', text());
 	return node;
 }
 
@@ -120,11 +153,11 @@ inline = opening:inlineOpening id:inlineIds ws0:__ attributes:(attributeList __)
 }
 
 inlineOpening = "<" {
-	return Node('inline.opening', line(), column(), offset(), text());
+	return Node('opening', line(), column(), offset(), text());
 }
 
 inlineClosing = slash:(slash __)? closing:closingAngleBracket {
-	var node = Node('inline.closing', line(), column(), offset(), text());
+	var node = Node('closing', line(), column(), offset(), text());
 
 	if (slash !== "") {
 		node.add('slash', slash[0]);
@@ -146,95 +179,91 @@ inlineIds = (
 	return node;
 }
 
-// ----------------------------------------------------------------------- CDATA
-
-cdata = opening:cdataOpening content:cdataContent closing:cdataClosing {
-	var node = Node('cdata', line(), column(), offset(), text());
-	node.add('opening', opening);
-	node.add('content', content);
-	node.add('closing', closing);
-	return node;
-}
-
-cdataOpening = "<![CDATA[" {
-	return Node('cdata.opening', line(), column(), offset(), text());
-}
-
-cdataClosing = endOfCdata {
-	return Node('cdata.closing', line(), column(), offset(), text());
-}
-
-cdataContent = (!endOfCdata .)* {
-	return Node('cdata.content', line(), column(), offset(), text());
-}
-
-endOfCdata = "]]>"
-
 // ----------------------------------------------------------------------- Block
 
-block = open:opening ws0:__ elements:(elementList __)? close:closing {
+block = open:opening ws0:__ nodes:(nodeList __)? close:closing {
 	var node = Node('block', line(), column(), offset(), text());
+
 	node.add('openTag', open);
+
 	node.addList('spaces.0', ws0);
-	if (elements !== "") {
-		node.addList('elements', elements[0]);
-		node.addList('spaces.1', elements[1]);
+
+	if (nodes !== "") {
+		node.addList('nodes', nodes[0]);
+		node.addList('spaces.1', nodes[1]);
 	}
+
 	node.add('closeTag', close);
+
 	return node;
 }
 
 opening = opening:openingOpening id:id ws0:__ attributes:(attributeList __)? closing:openingClosing {
 	var node = Node('opening', line(), column(), offset(), text());
+
 	node.add('opening', opening);
+
 	node.add('id', id);
+
 	node.addList('spaces.0', ws0);
+
 	if (attributes !== "") {
 		node.addList('attributes', attributes[0]);
 		node.addList('spaces.1', attributes[1]);
 	}
+
 	node.add('closing', closing);
+
 	return node;
 }
 
 openingOpening = "<" {
-	return Node('opening.opening', line(), column(), offset(), text());
+	return Node('opening', line(), column(), offset(), text());
 }
 
 openingClosing = ">" {
-	return Node('opening.closing', line(), column(), offset(), text());
+	return Node('closing', line(), column(), offset(), text());
 }
 
 closing = opening:closingOpening ws0:__ id:id ws1:__ closing:closingClosing {
 	var node = Node('closing', line(), column(), offset(), text());
+
 	node.add('opening', opening);
+
 	node.addList('spaces.0', ws0);
+
 	node.add('id', id);
+
 	node.addList('spaces.1', ws1);
+
 	node.add('closing', closing);
+
 	return node;
 }
 
 closingOpening = "</" {
-	return Node('closing.opening', line(), column(), offset(), text());
+	return Node('opening', line(), column(), offset(), text());
 }
 
 closingClosing = ">" {
-	return Node('closing.closing', line(), column(), offset(), text());
+	return Node('closing', line(), column(), offset(), text());
 }
 
 
 // ------------------------------------------------------------------- Attribute
 
-attribute = key:id value:(__ attributeAssignmentOperator __ attrvalue)? {
+attribute = key:id value:(__ attributeAssignmentOperator __ attrValue)? {
 	var node = Node('attribute', line(), column(), offset(), text());
+
 	node.add('key', key);
+
 	if (value !== "") {
 		node.addList('spaces.0', value[0]);
 		node.add('equal', value[1]);
 		node.addList('spaces.1', value[2]);
 		node.add('value', value[3]);
 	}
+
 	return node;
 }
 
@@ -247,9 +276,14 @@ attributeList = head:attribute rest:(__ attribute)* {
 	return lib.listFromSequence(head, rest);
 }
 
-attrvalue =
+attrValue =
 	string
-	/ word
+	/ unquotedAttr
+
+unquotedAttr = $(idhead idrest*) {
+	var node = Node('value', line(), column(), offset(), text());
+	return node;
+}
 
 // --------------------------------------------------------------------- Strings
 
@@ -261,9 +295,11 @@ doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent?
 	var node = Node('string', line(), column(), offset(), text());
 
 	node.add('opening', opening);
+
 	if (raw !== "") {
 		node.add('raw', raw);
 	}
+
 	node.add('closing', closing);
 
 	return node;
@@ -282,9 +318,11 @@ simpleQuoteString = opening:simpleQuoteStringQuote raw:simpleQuoteStringContent?
 	var node = Node('string', line(), column(), offset(), text());
 
 	node.add('opening', opening);
+
 	if (raw !== "") {
 		node.add('raw', raw);
 	}
+
 	node.add('closing', closing);
 
 	return node;
@@ -314,15 +352,15 @@ comment = opening:commentOpening content:commentContent? closing:commentClosing 
 }
 
 commentOpening = "<!--" {
-	return Node('comment.opening', line(), column(), offset(), text());
+	return Node('opening', line(), column(), offset(), text());
 }
 
 commentClosing = "-->" {
-	return Node('comment.closing', line(), column(), offset(), text());
+	return Node('closing', line(), column(), offset(), text());
 }
 
-commentContent = (!"-->" .)+ {
-	return Node('comment.content', line(), column(), offset(), text());
+commentContent = (!commentClosing .)+ {
+	return Node('content', line(), column(), offset(), text());
 }
 
 // --------------------------------------------------------------------- Various

--- a/app/node_modules/modes/html/parser/options.json
+++ b/app/node_modules/modes/html/parser/options.json
@@ -1,7 +1,7 @@
 {
 	"allowedStartRules": [
 		"start",
-		"elementList",
+		"nodeList",
 		"text",
 		"node",
 		"element",
@@ -18,7 +18,6 @@
 		"cdataOpening",
 		"cdataClosing",
 		"cdataContent",
-		"endOfCdata",
 		"block",
 		"opening",
 		"openingOpening",
@@ -29,7 +28,7 @@
 		"attribute",
 		"attributeAssignmentOperator",
 		"attributeList",
-		"attrvalue",
+		"attrValue",
 		"string",
 		"doubleQuoteString",
 		"doubleQuoteStringQuote",

--- a/test/app/node_modules/modes/html/parser/index/comment-output.json
+++ b/test/app/node_modules/modes/html/parser/index/comment-output.json
@@ -3,17 +3,17 @@
     "location": "1x1->3x25/0->59",
     "children": [
         {
-            "type": "html:comment.opening",
+            "type": "html:opening",
             "location": "1x1->1x5/0->4",
             "children": []
         },
         {
-            "type": "html:comment.content",
+            "type": "html:content",
             "location": "1x5->3x22/4->56",
             "children": []
         },
         {
-            "type": "html:comment.closing",
+            "type": "html:closing",
             "location": "3x22->3x60/56->59",
             "children": []
         }


### PR DESCRIPTION
Tests and parser generation options have been updated accordingly.

Fixed:
- directive content definition: requiring at least one character to match the rule, as for the others following the same pattern
- made the content of CDATA optional
- added a rule to parse unquoted tag attributes: more correct, they don't eat special characters and match id specs

Consistency:
- inverted the use of terms "elements" and "nodes": they were completely misused
- moved the CDATA declaration above the other elements definition, to match the order defined in the alternative of "elements"
- removed several prefixes in node types: like "comment.opening" to "opening", you can do a small node traversal to find out it's an opening of a comment (here the type is more like a category, not a unique identifier)
- avoided some useless rules or duplication for guarded closes used for rules like comment content, CDATA content, ...
