### PR TITLE
Added standard colors for stylesheet definition, plus visual emphasis of unparsed text.

### DIFF
--- a/app/node_modules/modes/node_modules/highlight/color.js
+++ b/app/node_modules/modes/node_modules/highlight/color.js
@@ -110,17 +110,64 @@ var Color = oop.Class({
 
 oop.addStatics(Color, {
 	defaults: {
+		// Grey scales ---------------------------------------------------------
+
 		'black': Color.greyScale(0),
+		'gray': Color.greyScale(128),
+		'silver': Color.greyScale(192),
 		'white': Color.greyScale(255),
-		'grey': Color.greyScale(128),
+
+		// Plain colors --------------------------------------------------------
+
 		'red': Color.redScale(255),
-		'green': Color.greenScale(255),
-		'blue': Color.blueScale(255)
+		'lime': Color.greenScale(255),
+		'blue': Color.blueScale(255),
+
+		'yellow': Color.rgb(255, 255, 0),
+		'aqua': Color.rgb(0, 255, 255),
+		'fushia': Color.rgb(255, 0, 255),
+
+		// Others --------------------------------------------------------------
+
+		'purple': Color.rgb(128, 0, 128),
+		'maroon': Color.redScale(128),
+		'olive': Color.rgb(128, 128, 0),
+		'teal': Color.rgb(0, 128, 128),
+		'navy': Color.blueScale(128),
 	}
 });
 
+// Add color aliases
 
+var aliases = {
+	'gray': ['grey', 'dark gray', 'dark grey'],
 
+	'red': ['high red'],
+	'maroon': ['low red'],
+
+	'olive': ['brown'],
+
+	'lime': ['high green'],
+	'green': ['low green'],
+
+	'aqua': ['high cyan'],
+	'teal': ['low cyan'],
+
+	'blue': ['high blue'],
+	'navy': ['low blue'],
+
+	'fushia': ['high magenta'],
+	'purple': ['low magenta']
+}
+
+for (var colorName in aliases) {
+	var color = Color.defaults[colorName];
+
+	var alternatives = aliases[colorName];
+	for (var i = 0, length = alternatives.length; i < length; i++) {
+		Color.defaults[alternatives[i]] = color;
+	}
+}
 
 
 exports.Color = Color;

--- a/app/node_modules/modes/node_modules/highlight/stylesheet.js
+++ b/app/node_modules/modes/node_modules/highlight/stylesheet.js
@@ -20,7 +20,10 @@ var Stylesheet = oop.Class({
 
 	statics: {
 		CLASS_PREFIX: "editor-highlight-",
-		DEFAULT_CLASS: "token"
+		DEFAULT_CLASS: "token",
+		// Hack for remaining unparsed text (see below)
+		UNPARSED_CLASS: "_unparsed",
+		_unparsed: Style({bg: 'black', color: 'white'})
 	},
 
 	methods: {
@@ -87,6 +90,8 @@ var Stylesheet = oop.Class({
 		css: function() {
 			var ruleSets = [];
 			ruleSets.push("." +  Stylesheet.CLASS_PREFIX + Stylesheet.DEFAULT_CLASS + "{" + this.default.css().join(';') + "}");
+			// Hack for remaining unparsed text (see method `html` in `Mode`)
+			ruleSets.push("." +  Stylesheet.CLASS_PREFIX + Stylesheet.UNPARSED_CLASS + "{" + Stylesheet._unparsed.css().join(';') + "}");
 			for (var selector in this.styles) {
 				var style = this.styles[selector];
 				var declarations = style.css();

--- a/app/node_modules/modes/node_modules/mode.js
+++ b/app/node_modules/modes/node_modules/mode.js
@@ -146,6 +146,16 @@ var Mode = oop.Class({
 
 			var ranges = this.highlight(code, input).ranges;
 
+			// Hack to append at the end any source code that has been taken into account by highlighting
+			// This can happen only when the source code and the corresponding graph are not in sync, because parsing failed. There is more text that what the "highlighting thinks".
+
+			var rangesEnd = ranges[ranges.length - 1].end;
+			if (rangesEnd < source.length) {
+				ranges.push({style: '_unparsed', start: rangesEnd, end: source.length})
+			}
+
+			// -----
+
 			var output = "";
 			for (var i = 0, length = ranges.length; i < length; i++) {
 				var range = ranges[i];


### PR DESCRIPTION
These colors use HTML colors names (http://en.wikipedia.org/wiki/Web_colors), along with the aliases.

Unparsed text handling:
- highlighting HTML output in Mode now handles unparsed text (the visual result assumes the unparsed text is always at the end, but this is not the case, and anyway you will see all the text, maybe with a very weird highlighting sometimes)
- the Stylesheet class also handles it (even if it is a bad design, see  ariatemplates/editor-backend#6)
