### PR TITLE
The HTML parser is now far more permissive.

### DIFF
--- a/app/node_modules/modes/html/parser/grammar.pegjs
+++ b/app/node_modules/modes/html/parser/grammar.pegjs
@@ -16,6 +16,8 @@
 			node.flag('block');
 		}
 	});
+
+	var blockOpeningStack = [];
 }
 
 
@@ -40,8 +42,8 @@ start = ws0:__ nodes:(nodeList __)? {
 // ----------------------------------------------------------------------- Nodes
 
 node =
-	text
-	/ element
+	element
+	/ text
 
 // FIXME This rule is used to parse a list of nodes contained in a block element (most of the time)
 // These nodes are a mix of text, elements, and comments also.
@@ -55,24 +57,67 @@ nodeList = head:node rest:(__ node)* {
 // ------------------------------------------------------------------------ Text
 // The particularity of the text node, is that it is not delimited as other nodes - that is elements, it's just everything that is not an element. So to detect the end of a text, we need to check if an element starts.
 
-text = content:$(!elementStart .)+ {
+text = $(!elementStart .)+ {
 	return Node('text', line(), column(), offset(), text());
 }
-
-elementStart = "<"
 
 // -------------------------------------------------------------------- Elements
 // WARNING the precedence in alternatives is important!
 
 element =
-	cdata
-	/ directive
+	directiveElement
 	/ inline
 	/ block
+	/ node:closing &{
+		// This closing has no ID, it's necessarily orphan ---------------------
+		var nodeID = node.childrenIndex.id;
+		if (nodeID == null) {
+			return true;
+		}
+
+		// There wasn't any block (with an ID of course) to close, this closing is an orphan -------
+		var lastBlockOpening = blockOpeningStack[blockOpeningStack.length - 1];
+		if (lastBlockOpening == null) {
+			return true;
+		}
+
+		// The closing ID doesn't match the latest opened block, it's orphan ---
+		var lastID = lastBlockOpening.childrenIndex.id;
+		return (lastID.source !== nodeID.source);
+	} {
+		node.flag('error');
+		node.set('error', "Closing tag doesn't match any opening tag");
+
+		return node;
+	}
+	/ (!closingOpening node:elementStart) {
+		node.flag('error');
+		node.set('error', 'Unknow element');
+		return node;
+	}
+
+elementStart = "<" {
+	return Node('opening', line(), column(), offset(), text());
+}
+
+// ---------------------------------------------------------- Directive elements
+
+directiveElement =
+	cdata
+	/ directive
+	/ node:directiveOpening {
+		node.flag('error');
+		node.set('error', 'Unknow directive element');
+		return node;
+	}
+
+directiveOpening = "<!" {
+	return Node('opening', line(), column(), offset(), text());
+}
 
 // ----------------------------------------------------------------------- CDATA
 
-cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing {
+cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing? {
 	var node = Node('cdata', line(), column(), offset(), text());
 
 	node.add('opening', opening);
@@ -81,7 +126,12 @@ cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing {
 		node.add('content', content);
 	}
 
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		node.set('error', 'CDATA block not closed');
+	}
 
 	return node;
 }
@@ -100,14 +150,22 @@ cdataContent = (!cdataClosing .)+ {
 
 // ------------------------------------------------------------------- Directive
 
-directive = opening:directiveOpening ws0:__ id:id ws1:__ content:directiveContent? closing:directiveClosing {
-	var node = Node('directive', line(), column(), offset(), text())
+directive = opening:directiveOpening ws0:__ id:id? ws1:__ content:directiveContent? closing:directiveClosing? {
+	var node = Node('directive', line(), column(), offset(), text());
+
+	var errors = [];
 
 	node.add('opening', opening);
 
 	node.addList('spaces.0', ws0);
 
-	node.add('id', id);
+	if (id !== "") {
+		node.add('id', id);
+	} else {
+		node.flag('error');
+		errors.push('Directive is missing id');
+		node.set('error', errors);
+	}
 
 	node.addList('spaces.1', ws1);
 
@@ -115,13 +173,15 @@ directive = opening:directiveOpening ws0:__ id:id ws1:__ content:directiveConten
 		node.add('content', content);
 	}
 
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		errors.push('Directive is not closed');
+		node.set('error', errors);
+	}
 
 	return node;
-}
-
-directiveOpening = "<!" {
-	return Node('opening', line(), column(), offset(), text());
 }
 
 directiveClosing = ">" {
@@ -135,7 +195,7 @@ directiveContent = (!">" .)+ {
 
 // ---------------------------------------------------------------------- Inline
 
-inline = opening:inlineOpening id:inlineIds ws0:__ attributes:(attributeList __)? closing:inlineClosing {
+inline = opening:inlineOpening id:inlineIds ws0:__ attributes:(attributeList __)? closing:inlineClosing? {
 	var node = Node('inline', line(), column(), offset(), text());
 
 	node.add('opening', opening);
@@ -147,7 +207,12 @@ inline = opening:inlineOpening id:inlineIds ws0:__ attributes:(attributeList __)
 		node.addList('spaces.1', attributes[1]);
 	}
 
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		node.set('error', 'Inline element not closed');
+	}
 
 	return node;
 }
@@ -181,8 +246,9 @@ inlineIds = (
 
 // ----------------------------------------------------------------------- Block
 
-block = open:opening ws0:__ nodes:(nodeList __)? close:closing {
+block = !closing open:opening ws0:__ nodes:(nodeList __)? close:closing? {
 	var node = Node('block', line(), column(), offset(), text());
+	var errors = [];
 
 	node.add('openTag', open);
 
@@ -193,17 +259,32 @@ block = open:opening ws0:__ nodes:(nodeList __)? close:closing {
 		node.addList('spaces.1', nodes[1]);
 	}
 
-	node.add('closeTag', close);
+	if (close !== "") {
+		node.add('closeTag', close);
+		blockOpeningStack.pop();
+	} else {
+		node.flag('error');
+		errors.push('Block is not closed');
+		node.set('error', errors);
+	}
 
 	return node;
 }
 
-opening = opening:openingOpening id:id ws0:__ attributes:(attributeList __)? closing:openingClosing {
+opening = opening:openingOpening id:id? ws0:__ attributes:(attributeList __)? closing:openingClosing? {
 	var node = Node('opening', line(), column(), offset(), text());
+	var errors = [];
 
 	node.add('opening', opening);
 
-	node.add('id', id);
+	if (id !== "") {
+		blockOpeningStack.push(node);
+		node.add('id', id);
+	} else {
+		node.flag('error');
+		errors.push('Block opening tag is missing id');
+		node.set('error', errors);
+	}
 
 	node.addList('spaces.0', ws0);
 
@@ -212,7 +293,13 @@ opening = opening:openingOpening id:id ws0:__ attributes:(attributeList __)? clo
 		node.addList('spaces.1', attributes[1]);
 	}
 
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		errors.push('Opening tag not closed');
+		node.set('error', errors);
+	}
 
 	return node;
 }
@@ -225,18 +312,31 @@ openingClosing = ">" {
 	return Node('closing', line(), column(), offset(), text());
 }
 
-closing = opening:closingOpening ws0:__ id:id ws1:__ closing:closingClosing {
+closing = opening:closingOpening ws0:__ id:id? ws1:__ closing:closingClosing? {
 	var node = Node('closing', line(), column(), offset(), text());
+	var errors = [];
 
 	node.add('opening', opening);
 
 	node.addList('spaces.0', ws0);
 
-	node.add('id', id);
+	if (id != "") {
+		node.add('id', id);
+	} else {
+		node.flag('error');
+		errors.push('Closing contains no id');
+		node.set('errors', errors);
+	}
 
 	node.addList('spaces.1', ws1);
 
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		errors.push('Closing tag not closed');
+		node.set('errors', errors);
+	}
 
 	return node;
 }
@@ -252,7 +352,7 @@ closingClosing = ">" {
 
 // ------------------------------------------------------------------- Attribute
 
-attribute = key:id value:(__ attributeAssignmentOperator __ attrValue)? {
+attribute = key:id value:(__ attributeAssignmentOperator __ attrValue?)? {
 	var node = Node('attribute', line(), column(), offset(), text());
 
 	node.add('key', key);
@@ -261,14 +361,19 @@ attribute = key:id value:(__ attributeAssignmentOperator __ attrValue)? {
 		node.addList('spaces.0', value[0]);
 		node.add('equal', value[1]);
 		node.addList('spaces.1', value[2]);
-		node.add('value', value[3]);
-	}
 
+		if (value[3] !== "") {
+			node.add('value', value[3]);
+		} else {
+			node.flag('error');
+			node.set('error', 'Attribute missing value');
+		}
+	}
 	return node;
 }
 
 attributeAssignmentOperator = "=" {
-	return Node('attribute-assignment-operator', line(), column(), offset(), text());
+	return Node('binary-operator', line(), column(), offset(), text());
 }
 
 // TODO handle white spaces without merging them with attributes
@@ -291,7 +396,7 @@ string =
 	doubleQuoteString
 	/ simpleQuoteString
 
-doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent? closing:doubleQuoteStringQuote {
+doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent? closing:doubleQuoteStringQuote? {
 	var node = Node('string', line(), column(), offset(), text());
 
 	node.add('opening', opening);
@@ -300,7 +405,12 @@ doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent?
 		node.add('raw', raw);
 	}
 
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		node.set('error', 'String not closed (missing double quote)');
+	}
 
 	return node;
 }
@@ -314,7 +424,7 @@ doubleQuoteStringContent = $(!'"' .)+ {
 }
 
 
-simpleQuoteString = opening:simpleQuoteStringQuote raw:simpleQuoteStringContent? closing:simpleQuoteStringQuote {
+simpleQuoteString = opening:simpleQuoteStringQuote raw:simpleQuoteStringContent? closing:simpleQuoteStringQuote? {
 	var node = Node('string', line(), column(), offset(), text());
 
 	node.add('opening', opening);
@@ -323,7 +433,12 @@ simpleQuoteString = opening:simpleQuoteStringQuote raw:simpleQuoteStringContent?
 		node.add('raw', raw);
 	}
 
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		node.set('error', 'String not closed (missing simple quote)');
+	}
 
 	return node;
 }
@@ -339,14 +454,19 @@ simpleQuoteStringContent = $(!"'" .)+ {
 
 // -------------------------------------------------------------------- Comments
 
-comment = opening:commentOpening content:commentContent? closing:commentClosing {
+comment = opening:commentOpening content:commentContent? closing:commentClosing? {
 	var node = Node('comment', line(), column(), offset(), text());
 
 	node.add('opening', opening);
 	if (content !== "") {
 		node.add('content', content);
 	}
-	node.add('closing', closing);
+	if (closing !== "") {
+		node.add('closing', closing);
+	} else {
+		node.flag('error');
+		node.set('error', 'Comment is not closed');
+	}
 
 	return node;
 }

--- a/test/app/node_modules/modes/html/parser/index/attributeList-output.json
+++ b/test/app/node_modules/modes/html/parser/index/attributeList-output.json
@@ -9,7 +9,7 @@
                 "children": []
             },
             {
-                "type": "html:attribute-assignment-operator",
+                "type": "html:binary-operator",
                 "location": "1x9->1x10/8->9",
                 "children": []
             },
@@ -89,7 +89,7 @@
                 }
             },
             {
-                "type": "html:attribute-assignment-operator",
+                "type": "html:binary-operator",
                 "location": "1x42->1x43/41->42",
                 "children": []
             },
@@ -134,7 +134,7 @@
                 "children": []
             },
             {
-                "type": "html:attribute-assignment-operator",
+                "type": "html:binary-operator",
                 "location": "1x64->1x65/63->64",
                 "children": []
             },
@@ -187,7 +187,7 @@
                 }
             },
             {
-                "type": "html:attribute-assignment-operator",
+                "type": "html:binary-operator",
                 "location": "1x85->1x86/84->85",
                 "children": []
             },


### PR DESCRIPTION
(tests have been fixed accordingly)

Made it more permissive and stores errors in nodes (flag them as having errors and set a property with a single error or a list). Also fixed some issues by the way.

Also, some nodes are marked as possible orphans: we should be able to parse them as they are, but outside of the context of the parent they should be in.

Here is a summary of the flexibility of the new grammar:
- most elements can be left open. When I say "element", I mean essentially any rule in the grammar which has a form: opening, content, closing.
- generally the content of these same elements has been made optional, or at least some parts of these contents
- there are other kind of rules that have been transformed to have optional parts. For instance, the attribute of a tag: when the assignment operator is present we expect a value but it can be left without
- when there are rules with only alternatives: if no alternative can be determined (too few characters), it falls back to a let's say abstract/generic super elements

Also brought more consistency and made important things optional:
- forced closing tags to match the latest opening tag, considering the id
- made it possible to parse alone not matching closing tags, considered as "orphans"
