### PR TITLE
Fixed the document id mess.

### DIFF
--- a/app/node_modules/modes/modeManager.js
+++ b/app/node_modules/modes/modeManager.js
@@ -40,21 +40,8 @@ var SessionInit = oop.Class({
 });
 
 
-var idPropertyNames = ['id', 'ID', 'guid', 'GUID', 'key', 'session'];
 
-var Request = oop.Class({
-	name: "Mode Request",
-
-	desc: "A mode request is the input for querying a service from a mode",
-
-	schema: {
-		properties: [
-			{names: idPropertyNames, required: true},
-			{names: ['service', 'svc', 'method', 'member'], required: true},
-			{names: ['arg', 'args', 'argument', 'arguments'], default: {}}
-		]
-	}
-});
+var idPropertyNames = ['id', 'ID', 'guid', 'GUID', 'key', 'hash', 'entry', 'session', 'document', 'doc'];
 
 var DocumentID = oop.Class({
 	name: "Document ID",
@@ -66,10 +53,25 @@ var DocumentID = oop.Class({
 			'String': 'id'
 		},
 		properties: [
-			{names: idPropertyNames, type: oop.types.Number, required: true}
+			{names: idPropertyNames, type: oop.types.String, required: true}
 		]
 	}
 });
+
+var Request = oop.Class({
+	name: "Mode Request",
+
+	desc: "A mode request is the input for querying a service from a mode",
+
+	schema: {
+		properties: [
+			{names: idPropertyNames, type: DocumentID, required: true},
+			{names: ['service', 'svc', 'method', 'member'], required: true},
+			{names: ['arg', 'args', 'argument', 'arguments'], default: {}}
+		]
+	}
+});
+
 
 
 var ModeManager = new oop.Class({
@@ -209,24 +211,24 @@ var ModeManager = new oop.Class({
 
 			// Response --------------------------------------------------------
 
-			return {
+			return DocumentID({
 				guid: id
-			};
+			});
 		},
 
-		getSessionData: function(id) {
-			if (id == null) {
+		getSessionData: function(document) {
+			if (document == null) {
 				throw {
-					msg: "No id given"
+					msg: "No document given"
 				}
 			}
 
-			var data = this.sessions.get(id);
+			var data = this.sessions.get(document.id);
 
 			if (data == null) {
 				throw {
 					msg: 'Invalid ID (no data)',
-					id: id
+					document: document
 				};
 			}
 

--- a/public/backend.js
+++ b/public/backend.js
@@ -71,7 +71,7 @@ function init(mode, source) {
 
 function service(doc, svc, arg) {
 	var argument = {
-		guid: doc.guid,
+		doc: doc,
 		svc: svc,
 		arg: arg
 	};
@@ -83,8 +83,8 @@ function service(doc, svc, arg) {
 	return editor("exec", argument);
 }
 
-function updateAll(guid, source) {
-	return service(guid, "update", {replace: true, source: source});
+function updateAll(doc, source) {
+	return service(doc, "update", {replace: true, source: source});
 }
 
 return {


### PR DESCRIPTION
- now returns the whole DocumentID instance after initialization of a document
- now a request accepts a real DocumentID input
- the id property of a DocumentID is now of type String instead of Number
- added aliases to define the id property of the DocumentID
- fixed the use of the returned document handle in the web application

Fixes #37
