### PR TITLE
Addition of the extension information on the parsed resource

### DIFF
--- a/app/node_modules/modes/at-html/parser/grammar.pegjs
+++ b/app/node_modules/modes/at-html/parser/grammar.pegjs
@@ -119,7 +119,7 @@ blockStatementClosingWithoutOpeningInHtmlBlock = opening:blockStatementClosingOp
 	if (id != "") {
 		innerNode.add('id', id);
 	}
-	validator.validateTag(innerNode, "at", "closing");
+	validator.validateTag(innerNode, "at", "closing", options.extension);
 
 	if (extra != "") {
 		innerNode.add('extra', extra)
@@ -221,7 +221,7 @@ blockStatementOpening = opening:blockStatementOpeningOpening !"/" id:id? param:b
 		node.addList('param', param);
 	}
 
-	validator.validateTag(node, "at", "opening");
+	validator.validateTag(node, "at", "opening", options.extension);
 
 	node.add('closing', closing);
 
@@ -247,7 +247,7 @@ blockStatementClosing = opening:blockStatementClosingOpening id:id? extra:extraP
 	if (id) {
 		node.add('id', id);
 	}
-	validator.validateTag(node, "at", "closing");
+	validator.validateTag(node, "at", "closing", options.extension);
 
 	if (extra) {
 		node.add('extra', extra)
@@ -289,7 +289,7 @@ inlineStatement = opening:inlineOpening id:id? param:inlineStatementParam? closi
 		node.addList('param', param);
 	}
 
-	validator.validateTag(node, "at", "inline");
+	validator.validateTag(node, "at", "inline", options.extension);
 
 	node.add('closing', closing);
 
@@ -653,7 +653,7 @@ blockHtmlTagOpening = opening:blockHtmlTagOpeningOpening !"/" id:htmlId? param:b
 		node.addList('param', param);
 	}
 
-	validator.validateTag(node, "html", "opening");
+	validator.validateTag(node, "html", "opening", options.extension);
 
 	node.add('closing', closing);
 
@@ -685,7 +685,7 @@ blockHtmlTagClosing =opening:blockHtmlTagClosingOpening  ws0:wsSequence? id:html
 	if (id) {
 		node.add('id', id);
 	}
-	validator.validateTag(node, "html", "closing");
+	validator.validateTag(node, "html", "closing", options.extension);
 
 	if (ws1) {
 		node.addList('spacesAfterId', ws1);
@@ -738,7 +738,7 @@ inlineHtmlElement = opening:inlineHtmlTagOpening id:htmlId? param:inlineHtmlTagP
 	}
 
 	node.add('closing', closing);
-	validator.validateTag(node, "html", "inline");
+	validator.validateTag(node, "html", "inline", options.extension);
 
 	return node;
 }

--- a/app/node_modules/modes/at-html/parser/validator.js
+++ b/app/node_modules/modes/at-html/parser/validator.js
@@ -82,9 +82,14 @@ atContext.Aria.load({
 			 * Returns true if the statement is a root statement
 			 *
 			 * @param {String} stm Statement name
+			 * @param {String} extension It can be "tpl" or "tml"
+			 *
 			 * @return {Boolean}
 			 */
-			isRoot: function(stm) {
+			isRoot: function(stm, extension) {
+				if (extension == "tml") {
+					return stm == "Library";
+				}
 				return stm == "Template";
 			},
 
@@ -148,13 +153,15 @@ atContext.Aria.load({
 			 * Validates the openingand closing tags of a block AT statement, an inline AT statement, the opening tag of an HTML element or an inline HTML element
 			 *
 			 * @param {Node} node Node containing the opening tag of a block statement/element or an inline statement/element
-			 * @param {String} type It can be "html-inline", "html-opening", "html-closing", "at-inline", "at-opening", "at-closing"
+			 * @param {String} language It can be "html" or "at"
+			 * @param {String} type It can be "inline", "opening" or "closing"
+			 * @param {String} extension It can be "tpl" or "tml"
 			 */
-			validateTag: function(node, language, type) {
+			validateTag: function(node, language, type, extension) {
 				if (language == "html") {
 					this.validateHTML(node, type);
 				} else {
-					this.validateAT(node, type);
+					this.validateAT(node, type, extension);
 				}
 			},
 
@@ -181,8 +188,9 @@ atContext.Aria.load({
 			 *
 			 * @param {Node} node Node containing the opening tag of a block statement or an inline statement
 			 * @param {String} type It can be "inline", "opening" or "closing"
+			 * @param {String} extension It can be "tpl" or "tml"
 			 */
-			validateAT: function(node, type) {
+			validateAT: function(node, type, extension) {
 
 				var isContainer = (type == "inline") ? false : true;
 				var id = node.childrenIndex.id ? node.childrenIndex.id.source : null;
@@ -192,7 +200,7 @@ atContext.Aria.load({
 					this.stopTracking();
 				} else {
 					if (type != "closing") {
-						this.validateATTracking(node, id);
+						this.validateATTracking(node, id, extension);
 					}
 
 					if (type == "opening") {
@@ -313,12 +321,13 @@ atContext.Aria.load({
 			 *
 			 * @param {Object} node Node to decorate with errors if needed
 			 * @param {String} stm Name of the statement
+			 * @param {String} extension It can be "tpl" or "tml"
 			 */
-			validateATTracking: function(node, stm) {
+			validateATTracking: function(node, stm, extension) {
 
 				if (tracking) {
 					// root validation
-					var isRoot = this.isRoot(stm);
+					var isRoot = this.isRoot(stm, extension);
 					if (isRoot && stack.length > 0) {
 						registerError(node, "Statement " + stm + " can only be used as root.");
 					}

--- a/app/node_modules/modes/modeManager.js
+++ b/app/node_modules/modes/modeManager.js
@@ -34,7 +34,8 @@ var SessionInit = oop.Class({
 	schema: {
 		properties: [
 			{names: ['mode', 'lang', 'language'], required: true},
-			{names: ['source', 'src', 'text', 'input', 'content']}
+			{names: ['source', 'src', 'text', 'input', 'content']},
+			{names: ['extension', 'ext']}
 		]
 	}
 });
@@ -200,7 +201,7 @@ var ModeManager = new oop.Class({
 
 			// source ----------------------------------------------------------
 
-			var code = this.modes[mode].create(spec.source);
+			var code = this.modes[mode].create(spec.source, spec.extension);
 
 			// Initialization --------------------------------------------------
 

--- a/app/node_modules/modes/node_modules/code.js
+++ b/app/node_modules/modes/node_modules/code.js
@@ -78,8 +78,9 @@ var Code = oop.class({
 	// 	]
 	// },
 
-	constructor: function(parser, input) {
+	constructor: function(parser, input, extension) {
 		this.parser = parser;
+		this.extension = extension;
 
 		this._source = '';
 		this._graph = undefined;
@@ -133,7 +134,7 @@ var Code = oop.class({
 				// this.updateGraph.process.call(this, spec);
 
 				try {
-					this._graph = this.parser.parse(this.source);
+					this._graph = this.parser.parse(this.source, {extension : this.extension});
 					return {
 						state: 'uptodate'
 					};
@@ -181,9 +182,9 @@ var Code = oop.class({
 
 			process: function(spec) {
 				if (spec.replace) {
-					this._graph = this.parser.parse(this.source);
+					this._graph = this.parser.parse(this.source, {extension : this.extension});
 				} else {
-					this._graph = this.parser.parse(this.source);
+					this._graph = this.parser.parse(this.source, {extension : this.extension});
 				}
 			}
 		}

--- a/app/node_modules/modes/node_modules/mode.js
+++ b/app/node_modules/modes/node_modules/mode.js
@@ -87,8 +87,8 @@ var Mode = oop.Class({
 		/**
 		 * Creates a code instance using this mode from the given source.
 		 */
-		create: function(source) {
-			return new Code(this.parser, source);
+		create: function(source, extension) {
+			return new Code(this.parser, source, extension);
 		},
 
 

--- a/test/app/node_modules/modes/at-html/parser/index/startTml-input.txt
+++ b/test/app/node_modules/modes/at-html/parser/index/startTml-input.txt
@@ -1,0 +1,10 @@
+{Library {
+	$classpath : "a.b.C"
+}}
+
+	{macro printTable()}
+		blablabla
+	{/macro}
+
+
+{/Library}

--- a/test/app/node_modules/modes/at-html/parser/index/startTml-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startTml-output.json
@@ -1,0 +1,205 @@
+{
+    "type": "at-html:root",
+    "location": "1x1->11x1/0->104",
+    "children": [
+        {
+            "type": "at-html:block-statement",
+            "location": "1x1->10x11/0->102",
+            "children": [
+                {
+                    "type": "at-html:opening",
+                    "location": "1x1->3x3/0->37",
+                    "children": [
+                        {
+                            "type": "at-html:opening",
+                            "location": "1x1->1x2/0->1",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:at-id",
+                            "location": "1x2->1x9/1->8",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:spaces",
+                            "location": "1x9->1x10/8->9",
+                            "children": [],
+                            "properties": {
+                                "size": 1
+                            }
+                        },
+                        {
+                            "type": "at-html:param",
+                            "location": "1x10->3x2/9->36",
+                            "children": [],
+                            "properties": {
+                                "value": "{\r\n\t$classpath : \"a.b.C\"\r\n}"
+                            }
+                        },
+                        {
+                            "type": "at-html:closing",
+                            "location": "3x2->3x38/36->37",
+                            "children": []
+                        }
+                    ]
+                },
+                {
+                    "type": "at-html:block-statement-content",
+                    "location": "3x3->10x1/37->92",
+                    "children": [
+                        {
+                            "type": "at-html:eols",
+                            "location": "3x3->5x1/37->41",
+                            "children": [],
+                            "properties": {
+                                "size": 2
+                            }
+                        },
+                        {
+                            "type": "at-html:tabs",
+                            "location": "5x1->5x43/41->42",
+                            "children": [],
+                            "properties": {
+                                "size": 1
+                            }
+                        },
+                        {
+                            "type": "at-html:block-statement",
+                            "location": "5x2->7x10/42->86",
+                            "children": [
+                                {
+                                    "type": "at-html:opening",
+                                    "location": "5x2->5x63/42->62",
+                                    "children": [
+                                        {
+                                            "type": "at-html:opening",
+                                            "location": "5x2->5x44/42->43",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:at-id",
+                                            "location": "5x3->5x49/43->48",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:spaces",
+                                            "location": "5x8->5x50/48->49",
+                                            "children": [],
+                                            "properties": {
+                                                "size": 1
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:param",
+                                            "location": "5x9->5x62/49->61",
+                                            "children": [],
+                                            "properties": {
+                                                "value": "printTable()"
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:closing",
+                                            "location": "5x21->5x63/61->62",
+                                            "children": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "at-html:block-statement-content",
+                                    "location": "5x22->7x2/62->78",
+                                    "children": [
+                                        {
+                                            "type": "at-html:eols",
+                                            "location": "5x22->6x1/62->64",
+                                            "children": [],
+                                            "properties": {
+                                                "size": 1
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:tabs",
+                                            "location": "6x1->6x67/64->66",
+                                            "children": [],
+                                            "properties": {
+                                                "size": 2
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:text",
+                                            "location": "6x3->7x2/66->78",
+                                            "children": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "at-html:closing",
+                                    "location": "7x2->7x87/78->86",
+                                    "children": [
+                                        {
+                                            "type": "at-html:opening",
+                                            "location": "7x2->7x81/78->80",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:at-id",
+                                            "location": "7x4->7x86/80->85",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:closing",
+                                            "location": "7x9->7x87/85->86",
+                                            "children": []
+                                        }
+                                    ]
+                                }
+                            ],
+                            "flags": [
+                                "block"
+                            ]
+                        },
+                        {
+                            "type": "at-html:eols",
+                            "location": "7x10->10x1/86->92",
+                            "children": [],
+                            "properties": {
+                                "size": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "at-html:closing",
+                    "location": "10x1->10x103/92->102",
+                    "children": [
+                        {
+                            "type": "at-html:opening",
+                            "location": "10x1->10x95/92->94",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:at-id",
+                            "location": "10x3->10x102/94->101",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:closing",
+                            "location": "10x10->10x103/101->102",
+                            "children": []
+                        }
+                    ]
+                }
+            ],
+            "flags": [
+                "block"
+            ]
+        },
+        {
+            "type": "at-html:eols",
+            "location": "10x11->11x1/102->104",
+            "children": [],
+            "properties": {
+                "size": 1
+            }
+        }
+    ]
+}

--- a/test/app/node_modules/modes/at-html/parser/index/startTmlOne-input.txt
+++ b/test/app/node_modules/modes/at-html/parser/index/startTmlOne-input.txt
@@ -1,0 +1,10 @@
+{Library {
+	$classpath : "a.b.C"
+}}
+
+	{macro printTable()}
+		blablabla
+	{/macro}
+
+
+{/Library}

--- a/test/app/node_modules/modes/at-html/parser/index/startTmlOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startTmlOne-output.json
@@ -1,0 +1,210 @@
+{
+    "type": "at-html:root",
+    "location": "1x1->11x1/0->104",
+    "children": [
+        {
+            "type": "at-html:block-statement",
+            "location": "1x1->10x11/0->102",
+            "children": [
+                {
+                    "type": "at-html:opening",
+                    "location": "1x1->3x3/0->37",
+                    "children": [
+                        {
+                            "type": "at-html:opening",
+                            "location": "1x1->1x2/0->1",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:at-id",
+                            "location": "1x2->1x9/1->8",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:spaces",
+                            "location": "1x9->1x10/8->9",
+                            "children": [],
+                            "properties": {
+                                "size": 1
+                            }
+                        },
+                        {
+                            "type": "at-html:param",
+                            "location": "1x10->3x2/9->36",
+                            "children": [],
+                            "properties": {
+                                "value": "{\r\n\t$classpath : \"a.b.C\"\r\n}"
+                            }
+                        },
+                        {
+                            "type": "at-html:closing",
+                            "location": "3x2->3x38/36->37",
+                            "children": []
+                        }
+                    ],
+                    "properties": {
+                        "errors": [
+                            "Statement Library cannot be used as root."
+                        ]
+                    }
+                },
+                {
+                    "type": "at-html:block-statement-content",
+                    "location": "3x3->10x1/37->92",
+                    "children": [
+                        {
+                            "type": "at-html:eols",
+                            "location": "3x3->5x1/37->41",
+                            "children": [],
+                            "properties": {
+                                "size": 2
+                            }
+                        },
+                        {
+                            "type": "at-html:tabs",
+                            "location": "5x1->5x43/41->42",
+                            "children": [],
+                            "properties": {
+                                "size": 1
+                            }
+                        },
+                        {
+                            "type": "at-html:block-statement",
+                            "location": "5x2->7x10/42->86",
+                            "children": [
+                                {
+                                    "type": "at-html:opening",
+                                    "location": "5x2->5x63/42->62",
+                                    "children": [
+                                        {
+                                            "type": "at-html:opening",
+                                            "location": "5x2->5x44/42->43",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:at-id",
+                                            "location": "5x3->5x49/43->48",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:spaces",
+                                            "location": "5x8->5x50/48->49",
+                                            "children": [],
+                                            "properties": {
+                                                "size": 1
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:param",
+                                            "location": "5x9->5x62/49->61",
+                                            "children": [],
+                                            "properties": {
+                                                "value": "printTable()"
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:closing",
+                                            "location": "5x21->5x63/61->62",
+                                            "children": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "at-html:block-statement-content",
+                                    "location": "5x22->7x2/62->78",
+                                    "children": [
+                                        {
+                                            "type": "at-html:eols",
+                                            "location": "5x22->6x1/62->64",
+                                            "children": [],
+                                            "properties": {
+                                                "size": 1
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:tabs",
+                                            "location": "6x1->6x67/64->66",
+                                            "children": [],
+                                            "properties": {
+                                                "size": 2
+                                            }
+                                        },
+                                        {
+                                            "type": "at-html:text",
+                                            "location": "6x3->7x2/66->78",
+                                            "children": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "at-html:closing",
+                                    "location": "7x2->7x87/78->86",
+                                    "children": [
+                                        {
+                                            "type": "at-html:opening",
+                                            "location": "7x2->7x81/78->80",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:at-id",
+                                            "location": "7x4->7x86/80->85",
+                                            "children": []
+                                        },
+                                        {
+                                            "type": "at-html:closing",
+                                            "location": "7x9->7x87/85->86",
+                                            "children": []
+                                        }
+                                    ]
+                                }
+                            ],
+                            "flags": [
+                                "block"
+                            ]
+                        },
+                        {
+                            "type": "at-html:eols",
+                            "location": "7x10->10x1/86->92",
+                            "children": [],
+                            "properties": {
+                                "size": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "at-html:closing",
+                    "location": "10x1->10x103/92->102",
+                    "children": [
+                        {
+                            "type": "at-html:opening",
+                            "location": "10x1->10x95/92->94",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:at-id",
+                            "location": "10x3->10x102/94->101",
+                            "children": []
+                        },
+                        {
+                            "type": "at-html:closing",
+                            "location": "10x10->10x103/101->102",
+                            "children": []
+                        }
+                    ]
+                }
+            ],
+            "flags": [
+                "block"
+            ]
+        },
+        {
+            "type": "at-html:eols",
+            "location": "10x11->11x1/102->104",
+            "children": [],
+            "properties": {
+                "size": 1
+            }
+        }
+    ]
+}

--- a/test/node_modules/parserTester.js
+++ b/test/node_modules/parserTester.js
@@ -8,6 +8,7 @@ var now = require("performance-now");
  * @param {Object} parser Instance of a parser
  * @param {Object} params It contains:
  * - rule {String}: the rule to use
+ * - type {String}: the file type
  * - output {Object|Array|String|Boolean}: the expected output. If false, it means that a failure is expected
  * @return {Object} It contains:
  * - output {Object|Array|String}: the actual output,
@@ -20,7 +21,8 @@ var testSingleParseOperation = function(parser, params) {
 	var start = now(), failure = false;
 	try {
 		var parsedTree = parser.parse(params.input, {
-			startRule: params.rule || "start"
+			startRule: params.rule || "start",
+			extension: params.extension
 		});
 	} catch(ex) {
 		failure = true;
@@ -218,6 +220,7 @@ var ParserTester = oop.Class({
 		 * - display {Boolean}: whether to output the expected file in the console,
 		 * - failure {Boolean}: whether the parser is expected to fail
 		 * - toFile {String}: if present, the value will be used in order to write the result
+		 * - extension {String}: file extension
 		 *
 		 * @return {Object} It contains:
 		 * - result {Boolean}: whether the output of the parser corresponds to the expected output stored in the file corresponding to the name. The comparison is flexible (see objectIncludes method documentation).
@@ -253,7 +256,8 @@ var ParserTester = oop.Class({
 					var singleOutput = testSingleParseOperation(this.parser, {
 						input: input[i],
 						output: !expectedOutput ? false : expectedOutput[i],
-						rule: params.rule
+						rule: params.rule,
+						extension: params.extension
 					});
 					output.output.push(singleOutput.output);
 					output.result = output.result && singleOutput.result;
@@ -266,7 +270,8 @@ var ParserTester = oop.Class({
 				output =  testSingleParseOperation(this.parser, {
 					input: input,
 					output: expectedOutput,
-					rule: params.rule
+					rule: params.rule,
+					extension: params.extension
 				});
 			}
 

--- a/test/test.js
+++ b/test/test.js
@@ -176,10 +176,13 @@ describe('Parsers', function(){
 				name: "multiLineCommentNoContent",
 				rule: "multiLineComment",
 				duration: 5
-			},
-			"doubleQuoteString",
-			"singleQuoteString",
-			{
+			}, {
+				name: "doubleQuoteString",
+				rule: "doubleQuoteString"
+			}, {
+				name: "singleQuoteString",
+				rule: "singleQuoteString"
+			}, {
 				name: "doubleQuoteString",
 				rule: "string",
 				duration: 3
@@ -439,8 +442,21 @@ describe('Parsers', function(){
 				name: "startEmpty",
 				rule: "start",
 				duration: 5
+			}, {
+				name: "startTml",
+				rule: "start",
+				duration: 15,
+				extension: "tml"
+			}, {
+				name: "startTmlOne",
+				rule: "start",
+				duration: 15
 			}
 		];
+
+		for (i = 0, len = tests.length; i < len; i++) {
+			tests[i].extension = tests[i].extension || "tpl";
+		}
 
 		runTests(tester, tests);
 


### PR DESCRIPTION
This commit introduces the possibility to specify an extension for the resource that has to be parsed. This extension is given as argument to the parser so that it can produce the correct tree according to the file extension. This way, `.tpl` and `.tml` files can be parsed with the same grammar.
## AT-HTML grammar

Addition change of the root statement validation according to the file extension.
## Code

When an instance of `Code` is created, the extension is provided as argument.
## Tests

Addition to tests and possibility to specify the extension of the content to test.
