### PR TITLE
Added benchmarks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
 		"stop": "node scripts/shutdown",
 
 		"watch": "node scripts/watch",
-		"test": "mocha"
+		"test": "mocha",
+
+		"benchmark": "node scripts/benchmark"
 	},
 	"bin": {
 		"editor-backend": "bin/svc",
@@ -62,7 +64,10 @@
 	"devDependencies": {
 		"chokidar": "*",
 		"performance-now": "*",
-		"mocha": "*"
+		"mocha": "*",
+		"benchmark": "*",
+		"colour": "*",
+		"tester": "git+https://github.com/ymeine/tester#version/latest"
 	},
 	"dependencies": {
 		"lodash": "2.x",

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -1,0 +1,11 @@
+// 3rd
+var prelude = require('prelude-ls');
+// app
+var benchmarker = require('../test/node_modules/benchmarker').benchmarker_2;
+// input
+var benchmarks = require('../test/benchmarks');
+
+
+prelude.each(function(benchmark) {
+	benchmarker(benchmark.name, benchmark.parsers, benchmark.inputs);
+}, benchmarks.modes);

--- a/test/benchmarks/at-html/index.js
+++ b/test/benchmarks/at-html/index.js
@@ -1,0 +1,32 @@
+var fs = require('fs');
+
+
+
+
+function readSource(name) {
+	return fs.readFileSync(__dirname + '/input/' + name + '.tpl', 'utf-8');
+}
+
+
+
+exports.parsers = [
+	{name: 'normal', parser: require('../../../app/node_modules/modes/at-html/parser').parser}
+];
+
+exports.inputs = [
+	{name: 'small', source: readSource('small')}
+	,
+	{name: 'medium', source: readSource('medium')} // issue: very long, and three times more with the most efficient parser!!!
+	,
+	{name: '200 lines', source: readSource('200-lines')}
+	,
+	{name: '500 lines', source: readSource('500-lines')}
+	// ,
+	// {name: '1000 lines', source: readSource('1000-lines')} // issue: can't finish
+	// ,
+	// {name: '1000 lines (2)', source: readSource('1000-lines-2')} // issue: can't finish
+	// ,
+	// {name: '1000 lines (3)', source: bigSource = readSource('big')} // issue: can't finish
+];
+
+exports.name = 'AT-HTML';

--- a/test/benchmarks/at-html/input/1000-lines-2.tpl
+++ b/test/benchmarks/at-html/input/1000-lines-2.tpl
@@ -1,0 +1,1010 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Default template for List Widget
+{Template {
+    $classpath:'aria.widgets.form.templates.TemplateMultiSelect',
+    $hasScript:true,
+    $res:{
+      footerRes : 'aria.resources.multiselect.FooterRes'
+    }
+}}
+    {macro main()}
+        // The Div is used to wrap the items with good looking border.
+        {@aria:Div data.cfg}
+                {section {id: 'Items', macro: 'renderList'} /}
+                {if (data.displayOptions.displayFooter)}
+                    {call footer()/}
+                {/if}
+        {/@aria:Div}
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/benchmarks/at-html/input/1000-lines.tpl
+++ b/test/benchmarks/at-html/input/1000-lines.tpl
@@ -1,0 +1,1042 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Default template for List Widget
+{Template {
+    $classpath:'aria.widgets.form.templates.TemplateMultiSelect',
+    $hasScript:true,
+    $res:{
+      footerRes : 'aria.resources.multiselect.FooterRes'
+    }
+}}
+    {macro main()}
+        // The Div is used to wrap the items with good looking border.
+        {@aria:Div data.cfg}
+                {section {id: 'Items', macro: 'renderList'} /}
+                {if (data.displayOptions.displayFooter)}
+                    {call footer()/}
+                {/if}
+        {/@aria:Div}
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/benchmarks/at-html/input/200-lines.tpl
+++ b/test/benchmarks/at-html/input/200-lines.tpl
@@ -1,0 +1,190 @@
+{Template {
+  $classpath : "samples.features.autoselect.AutoSelect",
+  $hasScript : true,
+  $css : ["samples.features.autoselect.AutoSelectCSS"]
+}}
+
+  {macro main ()}
+    <div><b>Widgets on the left have AutoSelect switched on, widgets on the right have AutoSelect switched off.</b></div>
+
+    <div class="sampleDiv" >
+      <div class="title">
+        Example of a TextField with AutoSelect, click in the field on the left then the field on the right.
+      </div>
+      <table><tbody>
+      <tr>
+        <td>
+        {@aria:TextField {
+          id : "txtf0",
+          label : "TextField ",
+          labelWidth:75,
+          width:200,
+          value: "Selected?",
+          autoselect: true
+        } /}
+        </td>
+        <td>
+        {@aria:TextField {
+          id : "txtf1",
+          helptext : "Hi",
+          width:200,
+          value: "Selected?",
+          autoselect: false
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a NumberField with AutoSelect, click in the field on the left then the field on the right.</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:NumberField {
+          id: "nf0",
+          label: "NumberField",
+          labelWidth:75,
+          width:200,
+          value: 55378008,
+          autoselect: true
+        }/}
+        </td>
+        <td>
+        {@aria:NumberField {
+          id: "nf1",
+          width:200,
+          value: 55378008,
+          autoselect: false
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a TimeField with AutoSelect, click in the field on the left then the field on the right.</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:TimeField {
+          id: "tf0",
+          label: "TimeField",
+          labelWidth:75,
+          width:200,
+          pattern:aria.utils.environment.Date.getTimeFormats().shortFormat,
+          value: new Date(),
+          autoselect: true
+        }/}
+        </td>
+        <td>
+        {@aria:TimeField {
+          id: "tf1",
+          width:200,
+          pattern:aria.utils.environment.Date.getTimeFormats().shortFormat,
+          value: new Date(),
+          autoselect: false
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a DateField with AutoSelect, click in the field on the left then the field on the right.</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:DateField {
+          id: "df0",
+          label: "DateField",
+          labelWidth:75,
+          width:200,
+          value: new Date (),
+          autoselect: true
+        }/}
+        </td>
+        <td>
+        {@aria:DateField {
+          id: "df1",
+          width:200,
+          value: new Date (),
+          autoselect: false
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a DatePicker with AutoSelect, click in the field on the left then the field on the right.</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:DatePicker {
+          id: "dp0",
+          label: "DatePicker",
+          labelWidth:75,
+          width:200,
+          value: new Date(),
+          autoselect: true
+        }/}
+        </td>
+        <td>
+        {@aria:DatePicker {
+          id: "dp1",
+          width:200,
+          value: new Date(),
+          autoselect: false
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a MultiSelect with AutoSelect, click in the field on the left then the field on the right.</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:MultiSelect {
+          id: "ms0",
+          label: "MultiSelect",
+          labelWidth:75,
+          width:200,
+          items:[{value:'Selected?'}],
+          value: ['Selected?'],
+          autoselect: true
+        }/}
+        </td>
+        <td>
+        {@aria:MultiSelect {
+          id: "ms1",
+          width:200,
+          items:[{value:'Selected?'}],
+          value: ['Selected?'],
+          autoselect: false
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a AutoComplete with AutoSelect, click in the field on the left then the field on the right.</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:AutoComplete {
+          id: "ac0",
+          label: "AutoComplete",
+          labelWidth:75,
+          width:200,
+          resourcesHandler : getNationsHandler(3),
+          value: "Selected?",
+          autoselect: true
+        }/}
+        </td>
+        <td>
+        {@aria:AutoComplete {
+          id: "ac1",
+          width:200,
+          resourcesHandler : getNationsHandler(3),
+          value: "Selected?",
+          autoselect: false
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+  {/macro}
+
+{/Template}

--- a/test/benchmarks/at-html/input/500-lines.tpl
+++ b/test/benchmarks/at-html/input/500-lines.tpl
@@ -1,0 +1,474 @@
+{Template {
+  $classpath : "samples.features.prefill.basic.PrefillSample",
+  $hasScript : true,
+  $css : ["samples.features.prefill.basic.PrefillSampleCSS"],
+  $dependencies : ['aria.utils.validators.AlphaInternational']
+}}
+
+  {macro main ()}
+    <div><b>Unless otherwise specified, widgets on the right have a prefill bound to the same portion of the data model to which the value of the widget on the left is bound</b></div>
+
+    <div class="sampleDiv" >
+      <div class="title">
+        Example of a TextField with an AlphaInternational validator: type "%^&" on the left
+      </div>
+      <table><tbody>
+      <tr>
+        <td>
+        {@aria:TextField {
+          id : "textf1",
+          label : "TextField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value1",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:TextField {
+          id : "textf2",
+          helptext : "Hi",
+          width:200,
+          bind : {
+            value : {
+              to : "value2",
+              inside : data
+            },
+            prefill : {
+              to : "value1",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a NumberField with native widget validation: type "aaa" on the left</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:NumberField {
+          id : "nf1",
+          label : "NumberField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value9",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:NumberField {
+          id : "nf2",
+          width:200,
+          bind : {
+            value : {
+              to : "value10",
+              inside : data
+            },
+            prefill : {
+              to : "value9",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+      <div class="title">
+        The prefill is not validated: type "aaa" on the left, the widget on the right is prefilled. Then focus on the widget on the right
+      </div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:TextField {
+          id : "textf3",
+          label : "TextField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value17",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:NumberField {
+          id : "nf3",
+          label : "NumberField ",
+          labelWidth :75,
+          width:200,
+          bind : {
+            value : {
+              to : "value18",
+              inside : data
+            },
+            prefill : {
+              to : "value17",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">type 9.51pm on the left. Click on the right, then delete the field on the right: the prefill value is restored.</div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:TimeField {
+          id : "timef1",
+          label : "TimeField ",
+          pattern : "HH:mm",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value13",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:TimeField {
+          id : "timef2",
+          width:200,
+          pattern : "HH:mm:ss",
+          bind : {
+            value : {
+              to : "value14",
+              inside : data
+            },
+            prefill : {
+              to : "value13",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">type 9.51pm on the left. Click on the right, then delete the field on the right: the prefill value is <b>NOT</b> restored. The prefill of the TimeField on the right is not directly bound to the value of the first one. Look at the script in order to see the logic that implements the binding.</div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:TimeField {
+          id : "timef3",
+          label : "TimeField ",
+          pattern : "HH:mm",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value19",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:TimeField {
+          id : "timef4",
+          width:200,
+          pattern : "HH:mm:ss",
+          bind : {
+            value : {
+              to : "value21",
+              inside : data
+            },
+            prefill : {
+              to : "value20",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">Example of prefill value already set in the data model when the template is displayed. Also, an alternative to the Text widget is implemented as in the use case</div>
+    <table><tbody>
+
+      <tr>
+        <td>
+        {@aria:DatePicker {
+          id : "dp1",
+          label : "DatePicker ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value3",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:DatePicker {
+          id : "dp2",
+          pattern : "EEEE d MMMM yyyy",
+          width:200,
+          bind : {
+            value : {
+              to : "value4",
+              inside : data
+            },
+            prefill : {
+              to : "value3",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {section {
+          id : "weekDayText",
+          bindRefreshTo : [{
+            to : "value4",
+            inside : data
+          },{
+            to : "value3",
+            inside : data
+          }],
+          macro : "textMacro"
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:DateField {
+          id : "df1",
+          label : "DateField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value7",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:DateField {
+          id : "df2",
+          pattern : "EEEE d MMMM yyyy",
+          width:200,
+          bind : {
+            value : {
+              to : "value8",
+              inside : data
+            },
+            prefill : {
+              to : "value7",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:MultiSelect {
+          id : "ms1",
+          helptext : "Multiselect",
+          activateSort: true,
+          label: "MultiSelect ",
+          labelWidth:75,
+          width:200,
+          fieldDisplay: "code",
+          fieldSeparator:',',
+          valueOrderedByClick: true,
+          maxOptions:7,
+          numberOfRows:4,
+          displayOptions : {
+            flowOrientation:'horizontal',
+            listDisplay: "both",
+            displayFooter : true
+          },
+          items: this.data.items,
+          bind:{
+            value : {
+              to : 'value5',
+              inside : data
+            }
+          }
+        }/}
+        </td>
+        <td>
+        {@aria:MultiSelect {
+          id : "ms2",
+          helptext : "Multiselect",
+          activateSort: true,
+          width:200,
+          fieldDisplay: "code",
+          fieldSeparator:',',
+          valueOrderedByClick: true,
+          maxOptions:7,
+          numberOfRows:4,
+          displayOptions : {
+            flowOrientation:'horizontal',
+            listDisplay: "both",
+            displayFooter : true
+          },
+          items: this.data.items1,
+          bind:{
+            value : {
+              to : 'value6',
+              inside : data
+            },
+            prefill : {
+              to : "value5",
+              inside : data
+            }
+          }
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">Example with helptext: select an option on the left, then delete the text inside the left widget: the helptext is restored in both fields</div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:SelectBox {
+          id : "sb1",
+          label : "SelectBox ",
+          labelWidth:75,
+          width:200,
+          helptext:"Type text or select",
+          options: data.items,
+          bind : {
+            value : {
+              to : "value11",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:SelectBox {
+          id : "sb2",
+          width:200,
+          helptext:"Type text or select",
+          options: data.items1,
+          bind : {
+            value : {
+              to : "value12",
+              inside : data
+            },
+            prefill : {
+              to : "value11",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:AutoComplete {
+          id : "ac1",
+          label:"AutoComplete ",
+          helptext:"country",
+          labelWidth:75,
+          width:200,
+          block:false,
+          resourcesHandler: getNationsHandler(3),
+          preselect: "always",
+          bind:{
+              "value" : {
+                inside : data,
+                to : "value15"
+              }
+          }
+        }/}
+        </td>
+        <td>
+        {@aria:AutoComplete {
+          id : "ac2",
+          helptext:"country",
+          labelWidth:75,
+          width:200,
+          block:false,
+          resourcesHandler: getNationsHandler(3),
+          preselect: "always",
+          bind:{
+              "prefill" : {
+                inside : data,
+                to : "value15"
+              },
+              "value" : {
+                inside : data,
+                to : "value16"
+              }
+          }
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+
+      <tr>
+        <td>
+        {@aria:Button {
+          label : "Confirm all",
+          onclick : "leavePrefillState"
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+  {/macro}
+
+
+  {macro textMacro ()}
+    {var weekday=["Sun","Mon","Tue","Wed","Thu","Fri","Sat"] /}
+    {var color = "black" /}
+    {var value = data.value4 /}
+    {var output = "" /}
+    {if !value}
+      {set color = "#DDDDDD" /}
+      {set value = data.value3 /}
+    {/if}
+    {if value}
+      {set output = weekday[value.getDay()] /}
+    {/if}
+
+    <div style="color:${color};">${output}</div>
+  {/macro}
+
+{/Template}

--- a/test/benchmarks/at-html/input/README.md
+++ b/test/benchmarks/at-html/input/README.md
@@ -1,0 +1,28 @@
+# Inputs
+
+## Small
+
+## Medium
+
+Taken from test, `startEight` I guess.
+
+## 200 lines
+
+From sample [`samples/features/autoselect/AutoSelect.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/features/autoselect/AutoSelect.tpl)
+
+## 500 lines
+
+From sample [`samples/features/prefill/basic/PrefillSample.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/features/prefill/basic/PrefillSample.tpl)
+
+## Big
+
+Large file (around 1000 lines) build from samples in [`ariatemplates/documentation-code`](https://github.com/ariatemplates/documentation-code)
+
+Following files in commit [`95ea912fce4f21c56ae937fdd43f89261eaab9a3`](https://github.com/ariatemplates/documentation-code/tree/95ea912fce4f21c56ae937fdd43f89261eaab9a3):
+
+* [`samples/features/prefill/basic/PrefillSample.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/features/prefill/basic/PrefillSample.tpl)
+* [`samples/widgets/widgetlibs/html/select/BaseSelectTag.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/widgets/widgetlibs/html/select/BaseSelectTag.tpl)
+* [`samples/features/refresh/TemplateRefresh.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/features/refresh/TemplateRefresh.tpl)
+* [`samples/utils/validators/group/Groups.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/utils/validators/group/Groups.tpl)
+* [`samples/features/prefill/usecase/PrefillSample.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/features/prefill/usecase/PrefillSample.tpl)
+* [`samples/utils/validators/basic/Basic.tpl`](https://github.com/ariatemplates/documentation-code/blob/95ea912fce4f21c56ae937fdd43f89261eaab9a3/samples/utils/validators/basic/Basic.tpl)

--- a/test/benchmarks/at-html/input/big.tpl
+++ b/test/benchmarks/at-html/input/big.tpl
@@ -1,0 +1,1050 @@
+{Template {
+  $classpath : "samples.features.prefill.basic.PrefillSample",
+  $hasScript : true,
+  $css : ["samples.features.prefill.basic.PrefillSampleCSS"],
+  $dependencies : ['aria.utils.validators.AlphaInternational']
+}}
+
+  {macro main ()}
+    <div><b>Unless otherwise specified, widgets on the right have a prefill bound to the same portion of the data model to which the value of the widget on the left is bound</b></div>
+
+    <div class="sampleDiv" >
+      <div class="title">
+        Example of a TextField with an AlphaInternational validator: type "%^&" on the left
+      </div>
+      <table><tbody>
+      <tr>
+        <td>
+        {@aria:TextField {
+          id : "textf1",
+          label : "TextField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value1",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:TextField {
+          id : "textf2",
+          helptext : "Hi",
+          width:200,
+          bind : {
+            value : {
+              to : "value2",
+              inside : data
+            },
+            prefill : {
+              to : "value1",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv" >
+        <div class="title">Example of a NumberField with native widget validation: type "aaa" on the left</div>
+      <table><tbody>  <tr>
+        <td>
+        {@aria:NumberField {
+          id : "nf1",
+          label : "NumberField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value9",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:NumberField {
+          id : "nf2",
+          width:200,
+          bind : {
+            value : {
+              to : "value10",
+              inside : data
+            },
+            prefill : {
+              to : "value9",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+      <div class="title">
+        The prefill is not validated: type "aaa" on the left, the widget on the right is prefilled. Then focus on the widget on the right
+      </div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:TextField {
+          id : "textf3",
+          label : "TextField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value17",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:NumberField {
+          id : "nf3",
+          label : "NumberField ",
+          labelWidth :75,
+          width:200,
+          bind : {
+            value : {
+              to : "value18",
+              inside : data
+            },
+            prefill : {
+              to : "value17",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">type 9.51pm on the left. Click on the right, then delete the field on the right: the prefill value is restored.</div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:TimeField {
+          id : "timef1",
+          label : "TimeField ",
+          pattern : "HH:mm",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value13",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:TimeField {
+          id : "timef2",
+          width:200,
+          pattern : "HH:mm:ss",
+          bind : {
+            value : {
+              to : "value14",
+              inside : data
+            },
+            prefill : {
+              to : "value13",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">type 9.51pm on the left. Click on the right, then delete the field on the right: the prefill value is <b>NOT</b> restored. The prefill of the TimeField on the right is not directly bound to the value of the first one. Look at the script in order to see the logic that implements the binding.</div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:TimeField {
+          id : "timef3",
+          label : "TimeField ",
+          pattern : "HH:mm",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value19",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:TimeField {
+          id : "timef4",
+          width:200,
+          pattern : "HH:mm:ss",
+          bind : {
+            value : {
+              to : "value21",
+              inside : data
+            },
+            prefill : {
+              to : "value20",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">Example of prefill value already set in the data model when the template is displayed. Also, an alternative to the Text widget is implemented as in the use case</div>
+    <table><tbody>
+
+      <tr>
+        <td>
+        {@aria:DatePicker {
+          id : "dp1",
+          label : "DatePicker ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value3",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:DatePicker {
+          id : "dp2",
+          pattern : "EEEE d MMMM yyyy",
+          width:200,
+          bind : {
+            value : {
+              to : "value4",
+              inside : data
+            },
+            prefill : {
+              to : "value3",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {section {
+          id : "weekDayText",
+          bindRefreshTo : [{
+            to : "value4",
+            inside : data
+          },{
+            to : "value3",
+            inside : data
+          }],
+          macro : "textMacro"
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:DateField {
+          id : "df1",
+          label : "DateField ",
+          labelWidth:75,
+          width:200,
+          bind : {
+            value : {
+              to : "value7",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:DateField {
+          id : "df2",
+          pattern : "EEEE d MMMM yyyy",
+          width:200,
+          bind : {
+            value : {
+              to : "value8",
+              inside : data
+            },
+            prefill : {
+              to : "value7",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:MultiSelect {
+          id : "ms1",
+          helptext : "Multiselect",
+          activateSort: true,
+          label: "MultiSelect ",
+          labelWidth:75,
+          width:200,
+          fieldDisplay: "code",
+          fieldSeparator:',',
+          valueOrderedByClick: true,
+          maxOptions:7,
+          numberOfRows:4,
+          displayOptions : {
+            flowOrientation:'horizontal',
+            listDisplay: "both",
+            displayFooter : true
+          },
+          items: this.data.items,
+          bind:{
+            value : {
+              to : 'value5',
+              inside : data
+            }
+          }
+        }/}
+        </td>
+        <td>
+        {@aria:MultiSelect {
+          id : "ms2",
+          helptext : "Multiselect",
+          activateSort: true,
+          width:200,
+          fieldDisplay: "code",
+          fieldSeparator:',',
+          valueOrderedByClick: true,
+          maxOptions:7,
+          numberOfRows:4,
+          displayOptions : {
+            flowOrientation:'horizontal',
+            listDisplay: "both",
+            displayFooter : true
+          },
+          items: this.data.items1,
+          bind:{
+            value : {
+              to : 'value6',
+              inside : data
+            },
+            prefill : {
+              to : "value5",
+              inside : data
+            }
+          }
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <div class="title">Example with helptext: select an option on the left, then delete the text inside the left widget: the helptext is restored in both fields</div>
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:SelectBox {
+          id : "sb1",
+          label : "SelectBox ",
+          labelWidth:75,
+          width:200,
+          helptext:"Type text or select",
+          options: data.items,
+          bind : {
+            value : {
+              to : "value11",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+        <td>
+        {@aria:SelectBox {
+          id : "sb2",
+          width:200,
+          helptext:"Type text or select",
+          options: data.items1,
+          bind : {
+            value : {
+              to : "value12",
+              inside : data
+            },
+            prefill : {
+              to : "value11",
+              inside : data
+            }
+          }
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+      <tr>
+        <td>
+        {@aria:AutoComplete {
+          id : "ac1",
+          label:"AutoComplete ",
+          helptext:"country",
+          labelWidth:75,
+          width:200,
+          block:false,
+          resourcesHandler: getNationsHandler(3),
+          preselect: "always",
+          bind:{
+              "value" : {
+                inside : data,
+                to : "value15"
+              }
+          }
+        }/}
+        </td>
+        <td>
+        {@aria:AutoComplete {
+          id : "ac2",
+          helptext:"country",
+          labelWidth:75,
+          width:200,
+          block:false,
+          resourcesHandler: getNationsHandler(3),
+          preselect: "always",
+          bind:{
+              "prefill" : {
+                inside : data,
+                to : "value15"
+              },
+              "value" : {
+                inside : data,
+                to : "value16"
+              }
+          }
+        }/}
+        </td>
+      </tr>
+    </tbody></table>
+    </div>
+    <div class="sampleDiv">
+    <table><tbody>
+
+      <tr>
+        <td>
+        {@aria:Button {
+          label : "Confirm all",
+          onclick : "leavePrefillState"
+        } /}
+        </td>
+      </tr>
+    </tbody></table>
+  {/macro}
+
+
+  {macro textMacro ()}
+    {var weekday=["Sun","Mon","Tue","Wed","Thu","Fri","Sat"] /}
+    {var color = "black" /}
+    {var value = data.value4 /}
+    {var output = "" /}
+    {if !value}
+      {set color = "#DDDDDD" /}
+      {set value = data.value3 /}
+    {/if}
+    {if value}
+      {set output = weekday[value.getDay()] /}
+    {/if}
+
+    <div style="color:${color};">${output}</div>
+  {/macro}
+
+{macro main ()}
+
+ {var myOptions = [{value : "EURO",
+                    label : "France"
+                   }, {
+                    value : "FRANC SUISSE",
+                    label : "Switzerland"
+                   }, {
+                    value : "POUND",
+                    label : "United Kingdom"
+                   }]/}
+
+ {var myFancyOptions = [{value : "EURO",
+                    label : "France"
+                   }, {
+                    value : "FRANC SUISSE",
+                    label : "Switzerland",
+                    attributes:{
+                      disabled : "disabled"
+                    }
+                   }, {
+                    value : "POUND",
+                    label : "United Kingdom"
+                   }]/}
+
+ {var myStringOptions = ["EURO","FRANC SUISSE","POUND"]/}
+
+<p>
+
+We have 2 main types of select :
+<br>
+<br>
+<h2>using the options property</h2>
+<br>
+
+<h3>binding the value</h3>
+<br>
+{@html:Select {
+  attributes : {
+    classList : ["stylish"]
+  },
+  options : myOptions,
+  bind : {
+    value : {
+      inside : data,
+      to : "selectedCurrency"
+    }
+  }
+}/}
+<br>
+<br>
+
+<h3>using an array of strings to create the select</h3>
+<br>
+Each string from you array will be used to fill 'label' and 'value' in the options tag
+{@html:Select {
+  attributes : {
+    classList : ["stylish"]
+  },
+  options : myStringOptions,
+  bind : {
+    value : {
+      inside : data,
+      to : "selectedCurrency"
+    }
+  }
+}/}
+<br>
+
+
+your options can have 3 different properties: a value, a label, and a set of attributes(here we disable the second item)
+<br>
+{@html:Select {
+  attributes : {
+    classList : ["stylish"]
+  },
+  options : myFancyOptions,
+  bind : {
+    value : {
+      inside : data,
+      to : "selectedCurrency"
+    }
+  }
+}/}
+<br>
+<br>
+<h3>binding the index</h3>
+<br>
+
+{@html:Select {
+  attributes : {
+    classList : ["stylish"]
+  },
+  options : myOptions,
+  bind : {
+    selectedIndex : {
+      inside : data,
+      to : "selectedIndex"
+    }
+  }
+}/}
+<br>
+<div  style="background-color: yellow">
+this section is bound to the selected index
+<br>
+{section {
+  id : "displayCountindex",
+  macro : "BoundIndex",
+  bindRefreshTo : [
+    {
+      inside : data,
+      to : "selectedIndex"
+    }
+  ]
+}/}
+</div
+<br>
+<br>
+
+//same select implemented with a free html content
+<h2>using an html body content</h2>
+<br>
+{@html:Select {
+  attributes : {
+    classList : ["stylish"]
+  },
+  bind : {
+    value : {
+      inside : data,
+      to : "selectedCurrency"
+    }
+  }
+}}
+    {foreach option in myOptions}
+        <option value="${option.value}">${option.label}</option>
+    {/foreach}
+
+{/@html:Select}
+<br>
+<br>
+<div style="background-color: yellow">
+this section is bound to the selected value
+<br>
+{section {
+  id : "displayCount",
+  macro : "BoundValue",
+  bindRefreshTo : [
+    {
+      inside : data,
+      to : "selectedCurrency"
+    }
+  ]
+}/}
+</div>
+</p>
+
+{/macro}
+
+{macro BoundValue()}
+
+Selected currency : <strong>${data.selectedCurrency}</strong> .
+
+{/macro}
+
+{macro BoundIndex()}
+
+Selected index : <strong>${data.selectedIndex}</strong>.
+
+{/macro}
+
+  {macro main()}
+    {call sectionBinding()/}
+    <hr/>
+    {var doInit = initCountIfNeeded() /}
+    <br/>
+    <b>Main macro:</b> Count=${data["view:count"]}<br/>
+
+    {section "Section1"}
+      <b>Section1:</b> Count=${data["view:count"]}
+    {/section}<br/>
+
+    {for var i=0;3>i;i++}
+      {section "SectionX_"+i}
+        <b>SectionX_${i}:</b> Count=${data["view:count"]}<br/>
+        {for var j=0;2>j;j++}
+          {section "SectionX_"+i+"_"+j}
+            <b>SectionX_${i}_${j}:</b> Count=${data["view:count"]}
+          {/section}<br/>
+        {/for}
+      {/section}
+    {/for}
+    {section "sectionMacroRefresh"}
+      {call macroRefresh()/}
+    {/section}<br/>
+
+    <br/>
+    {for var i=1;3>i;i++}
+      // 2 Fields bound to the same data !
+      {@aria:TextField {
+        label:'Count Value (display #'+i+'):',
+        tooltip:'Type any value to update the counter (note: you will need to explicitly call of a refresh to update non-bound data)',
+        bind:{
+          value:{to:"view:count", inside:data}
+        }
+      }/}
+      <br/>
+    {/for}
+    <br/>
+
+    Refresh:
+    {@aria:Button {
+      label:'All',
+      onclick:'updateCountAndRefresh'
+    }/}
+    {@aria:Button {
+      label:'Section1',
+      onclick:{ fn: updateCountAndRefresh, args: {filterSection:"Section1"} }
+    }/}
+    {@aria:Button {
+      label:'SectionX_1',
+      onclick:{ fn: updateCountAndRefresh, args: {filterSection:"SectionX_1"} }
+    }/}
+    {@aria:Button {
+      label:'SectionX_1_1',
+      onclick:{ fn: updateCountAndRefresh, args: {filterSection:"SectionX_1_1"} }
+    }/}
+    {@aria:Button {
+      label:'macroRefresh',
+      onclick:{ fn: updateCountAndRefresh, args: {outputSection:"sectionMacroRefresh", macro: "macroRefresh"} }
+    }/}
+
+
+  {/macro}
+
+  {macro macroRefresh()}
+    <b>macroRefresh:</b> Count=${data["view:count"]}
+  {/macro}
+
+  {macro sectionBinding()}
+    <h2>Section Bindings</h2>
+
+    {section {
+      id: "SectionA",
+      bindRefreshTo : [{inside: data, to: "sectionRefresh"}]
+    }}
+      <p>
+        {@aria:NumberField {
+          label:"Bound Number field:",
+          labelPos:"left",
+          labelAlign:"right",
+          block:true,
+          value:'0',
+          disabled: true,
+          value:data['sectionRefresh'],
+          errorMessages:["Please type in a number"]
+        }/}
+        <br/>
+        {@aria:Button {
+          label:"Increment value in datamodel ++",
+          onclick: {
+              fn: "onclickrefresh",
+              args: "2"
+          }
+        }/}
+      </p>
+      <br/>
+        {section "SectionA1"}
+          <h2>Child Section</h2>
+          <p>Bound number field should show <b>${data.sectionRefresh}</b></p>
+        {/section}
+      {call sectionBinding2()/}
+    {/section}
+  {/macro}
+  {macro sectionBinding2()}
+    {section "SectionA2"}
+      <h2>Child Section within a sub macro</h2>
+      <p>The bound number field should show <b>${data.sectionRefresh}</b></p>
+    {/section}
+  {/macro}
+
+{var titleMessage = null /}
+
+  {macro main()}
+      <h2>Validator Groups</h2>
+      The first name and last name fields validators are a member of group 1, and the phone number and email address fields validators are a member of group 2.
+      <br>By clicking on one of the buttons below the associated group will be validated.
+      {@aria:ErrorList {
+        width: 650,
+        margins: "10 1 10 1",
+        title: "Success",
+        filterTypes: ['O'],
+        bind: {
+          messages: {
+            to: "errorMessages",
+            inside: data
+          }
+        }
+      }/}
+      {@aria:ErrorList {
+        width: 650,
+        margins: "10 1 10 1",
+        title: "Errors",
+        filterTypes: ['E'],
+        bind: {
+          messages: {
+            to: "errorMessages",
+            inside: data
+          }
+        }
+      }/}
+        <br/>
+        {@aria:TextField {
+          label: "First Name:",
+          labelWidth: 100,
+          bind: {
+            value: {
+              to: "firstName",
+              inside: data
+            }
+          }
+        }/}
+        <br/>
+        {@aria:TextField {
+          label: "Last Name:",
+          labelWidth: 100,
+          bind: {
+            value: {
+              to: "lastName",
+              inside: data
+            }
+          }
+        }/}
+        <br/>
+        {@aria:TextField {
+          label: "Phone Number:",
+          labelWidth: 100,
+          bind: {
+            value: {
+              to: "phoneNumber",
+              inside: data
+            }
+          }
+        }/}
+        <br/>
+        {@aria:TextField {
+          label: "Email Address:",
+          labelWidth: 100,
+          bind: {
+            value: {
+              to: "email",
+              inside: data
+            }
+          }
+        }/}
+        <br/><br/>
+        {@aria:Button {
+          label: "Validate Group1",
+          onclick: {
+            fn : "submit",
+            scope : moduleCtrl,
+            args : ["group1"]
+          }
+        }/}
+        {@aria:Button {
+          label: "Validate Group2",
+          onclick: {
+            fn : "submit",
+            scope : moduleCtrl,
+            args : ["group2"]
+          }
+        }/}
+        {@aria:Button {
+          label: "Validate All",
+          onclick: {
+            fn : "submit",
+            scope : moduleCtrl
+          }
+        }/}
+  {/macro}
+
+  {macro main ()}
+  <table><tbody>
+  <tr>
+    <td>From</td><td>To</td><td>Date</td><td>Airlines</td>
+  </tr>
+  {foreach item inArray data.flights}
+    <tr>
+      <td>
+      {@aria:AutoComplete {
+        width:75,
+        block:false,
+        resourcesHandler: getCitiesHandler(3),
+        preselect: "always",
+        bind:{
+            "value" : {
+              inside : item.from,
+              to : "value"
+            },
+            "prefill" : {
+              inside : item.from,
+              to : "prefill"
+            }
+        }
+      }/}
+      </td>
+      <td>
+      {@aria:AutoComplete {
+        width:75,
+        block:false,
+        resourcesHandler: getCitiesHandler(3),
+        preselect: "always",
+        bind:{
+            "value" : {
+              inside : item.to,
+              to : "value"
+            },
+            "prefill" : {
+              inside : item.to,
+              to : "prefill"
+            }
+        }
+      }/}
+      </td>
+      <td>
+      {@aria:DatePicker {
+        bind : {
+            "value" : {
+              inside : item.date,
+              to : "value"
+            },
+            "prefill" : {
+              inside : item.date,
+              to : "prefill"
+            }
+        }
+      } /}
+      </td>
+      <td>
+      {@aria:MultiSelect {
+        activateSort: true,
+        width:200,
+        fieldDisplay: "code",
+        fieldSeparator:',',
+        valueOrderedByClick: true,
+        maxOptions:7,
+        numberOfRows:4,
+        displayOptions : {
+          flowOrientation:'horizontal',
+          listDisplay: "both",
+          displayFooter : true
+        },
+        items: this.data.items,
+        bind:{
+            "value" : {
+              inside : item.airlines,
+              to : "value"
+            },
+            "prefill" : {
+              inside : item.airlines,
+              to : "prefill"
+            }
+        }
+      }/}
+      </td>
+      <td>
+        {@aria:Button {
+          label : "Remove",
+          onclick : {fn : "removeSegment", scope : this, args : item.index}
+        } /}
+      </td>
+    </tr>
+  {/foreach}
+  </tbody></table>
+
+  <div>
+  {@aria:Button {
+    label : "Add segment",
+    onclick : "addSegment"
+  } /}
+  </div>
+  {/macro}
+
+{var titleMessage = null /}
+
+  {macro main()}
+      <h2>Error Management</h2>
+      - A Mandatory validator is used for all fields, and can be triggered onsubmit:
+      <br/><br/>
+      {@aria:ErrorList {
+        defaultTemplate: "samples.utils.validators.basic.CustomizedErrorList",
+        margins: "10 1 10 1",
+        title: "Success",
+        filterTypes: ['O'],
+        bind: {
+          messages: {
+            to: "errorMessages",
+            inside: data
+          }
+        }
+      }/}
+      {@aria:ErrorList {
+        defaultTemplate: "samples.utils.validators.basic.CustomizedErrorList",
+        margins: "10 1 10 1",
+        title: "Information",
+        filterTypes: ['I'],
+        bind: {
+          messages: {
+            to: "errorMessages",
+            inside: data
+          }
+        }
+      }/}
+      {@aria:ErrorList {
+        defaultTemplate: "samples.utils.validators.basic.CustomizedErrorList",
+        margins: "10 1 10 1",
+        title: "Errors",
+        filterTypes: ['E'],
+        bind: {
+          messages: {
+            to: "errorMessages",
+            inside: data
+          }
+        }
+      }/}
+      {@aria:TextField {
+        label: "First Name:",
+        labelWidth: 100,
+        bind: {
+          value: {
+            to: "firstName",
+            inside: data
+          }
+        }
+      }/}
+      <br/>
+      {@aria:TextField {
+        label: "Last Name:",
+        labelWidth: 100,
+        bind: {
+          value: {
+            to: "lastName",
+            inside: data
+          }
+        }
+      }/}
+      <br/>
+      {@aria:TextField {
+        label: "Phone Number:",
+        labelWidth: 100,
+        bind: {
+          value: {
+            to: "phoneNumber",
+            inside: data
+          }
+        }
+      }/}
+      <br/>
+      {@aria:TextField {
+        label: "Email Address:",
+        labelWidth: 100,
+        bind: {
+          value: {
+            to: "email",
+            inside: data
+          }
+        }
+      }/}
+      <br/><br/>
+      {@aria:Button {
+        label: "Submit",
+        onclick: {
+          fn : "submit",
+          scope : moduleCtrl
+        }
+      }/}
+  {/macro}
+{/Template}

--- a/test/benchmarks/at-html/input/extractor.ls
+++ b/test/benchmarks/at-html/input/extractor.ls
@@ -1,0 +1,133 @@
+require! {
+	fs
+	node-path: path
+
+	prelude: 'prelude-ls'
+}
+
+const folder = 'G:/dev/github/ariatemplates/temp/documentation-code/samples'
+
+# Get list of files ------------------------------------------------------------
+
+# files = []
+
+getNodeType = (path) ->
+	stats = fs.statSync path
+
+	switch
+	| stats.isFile! => 'file'
+	| stats.isDirectory! => 'directory'
+
+getFilesInfo = (path) ->
+	stats = fs.statSync path
+	content = fs.readFileSync path, 'utf-8'
+
+	{
+		stats.size
+		lines: content.split /\r\n|[\r\n]/g .length
+	}
+
+processFolder = (path, filter) ->
+	nodes = fs.readdirSync path
+
+	nodes = for node in nodes
+		fullpath = node-path.join path, node
+		{
+			fullpath
+			type: getNodeType fullpath
+		}
+
+	if filter? => nodes = [node for node in nodes | filter node]
+
+	for node in nodes | node.type is 'directory'
+		node.nodes = processFolder node.fullpath, filter
+
+	nodes
+
+traverse = (node, cb) ->
+	cb node
+	if node.type is 'directory' => for node in node.nodes => traverse node, cb
+
+
+
+nodes = processFolder folder #, filter
+
+templates = []
+for node in nodes
+	traverse node, (node) ->
+		if node.type is 'file' and node-path.extname(node.fullpath) is '.tpl'
+			templates.push node
+
+templates = for template in templates
+	infos = getFilesInfo template.fullpath
+	{
+		template.fullpath
+		infos.size
+		infos.lines
+		ratio: infos.size / infos.lines
+	}
+console.log templates.length
+console.log!
+
+# ratios -----------------------------------------------------------------------
+
+ratios = [template.ratio for template in templates]
+# console.log ratios
+
+sum = (values) ->
+	result = 0
+	for number in values => result += number
+	result
+mean = (values) -> sum(values) / values.length
+
+console.log mean ratios
+
+# by lines ---------------------------------------------------------------------
+
+if no
+	sortedByLines = templates.sort (a, b) ->
+		a .= lines
+		b .= lines
+
+		switch
+		| a > b => 1
+		| a is b => 0
+		| a < b => -1
+
+# logs -------------------------------------------------------------------------
+
+# sortedByLines.reverse!
+# console.log sortedByLines
+
+# console.log mean ratios
+
+# extract ----------------------------------------------------------------------
+
+if no
+	templates = sortedByLines.reverse!
+
+	kept = []
+	minLines = 1000
+	maxRatio = mean ratios
+	currentLines = 0
+	for template in templates | currentLines < minLines
+		if template.ratio <= maxRatio
+			kept.push template
+			currentLines += template.lines
+
+	# console.log kept
+	# console.log currentLines
+
+	# for tpl in kept => console.log tpl.fullpath
+
+
+# extract fixed number of lines ------------------------------------------------
+
+extractFixed = (lines) ->
+	distances = prelude.sortBy (.length), [{
+		length: prelude.abs template.lines - lines
+		template
+	} for template in templates]
+
+console.log extractFixed(200).0
+console.log extractFixed(500).0

--- a/test/benchmarks/at-html/input/medium.tpl
+++ b/test/benchmarks/at-html/input/medium.tpl
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Default template for List Widget
+{Template {
+    $classpath:'aria.widgets.form.templates.TemplateMultiSelect',
+    $hasScript:true,
+    $res:{
+      footerRes : 'aria.resources.multiselect.FooterRes'
+    }
+}}
+    {macro main()}
+        // The Div is used to wrap the items with good looking border.
+        {@aria:Div data.cfg}
+                {section {id: 'Items', macro: 'renderList'} /}
+                {if (data.displayOptions.displayFooter)}
+                    {call footer()/}
+                {/if}
+        {/@aria:Div}
+    {/macro}
+
+    {macro renderList(item)}
+        {if (data.displayOptions.flowOrientation == 'horizontal')}
+            // with columns, horizontal
+            <table>
+            {foreach item inView data.itemsView}
+                {if item_index % data.numberOfColumns == 0}
+                    <tr>
+                {/if}
+
+                <td>{call renderItem(item, item_info.initIndex)/}</td>
+                {if (data.displayOptions.tableMode == true)}
+                    {var checkboxLabelSplit = item.label.split('|')/}
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[0]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[1]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[2]}</td>
+                    <td {on click {fn: "itemTableClick", args: {    item : item, itemIdx : item.index }}/}>${checkboxLabelSplit[3]}</td>
+                {/if}
+
+                {if (item_index + 1) % data.numberOfColumns == 0}
+                    </tr>
+                {/if}
+            {/foreach}
+            </table>
+        {elseif (data.displayOptions.flowOrientation == 'vertical')/}
+            {var lineCount = data.numberOfRows /}
+            {var columnCount = data.numberOfColumns /}
+            {var outputCount = 0 /}
+            {var outputRows = 1 /}
+            <table>
+            {for var i = 0 ; i < lineCount ; i++}
+                <tr>
+                {var lastColCount = 0 /}
+                {for var j = 0 ; j < columnCount ; j++ }
+                    <td>
+                    {var itemIndex = (j*lineCount)+i/}
+                    {if (itemIndex < data.itemsView.items.length)}
+                        {var item = data.itemsView.items[itemIndex].value/}
+                        {call renderItem(item, itemIndex)/}
+                    {/if}
+                    {set outputCount = outputCount + 1/}
+                    </td>
+                {/for}
+                {set outputRows = outputRows + 1/}
+                </tr>
+            {/for}
+            </table>
+        {else/}
+            {foreach item inView data.itemsView}
+                {call renderItem(item, item_info.initIndex)/}
+            {/foreach}
+        {/if}
+    {/macro}
+
+    {macro renderItem(item)}
+
+        {var checkboxLabel = "Error"/}
+        {if (data.displayOptions.listDisplay == 'code')}
+            {set checkboxLabel = item.value/}
+        {elseif (data.displayOptions.listDisplay == 'label')/}
+            {set checkboxLabel = item.label/}
+        {elseif (data.displayOptions.listDisplay == 'both')/}
+            {set checkboxLabel = item.label + " (" + item.value + ") " /}
+        {/if}
+        {if (data.displayOptions.tableMode == true)}
+            {set checkboxLabel = ""/}
+        {/if}
+
+
+        {@aria:CheckBox {
+            label: checkboxLabel,
+            onchange: {
+                fn: "itemClick",
+                args: {
+                    item : item,
+                    itemIdx : item.index
+                }
+            },
+            id: 'listItem' + item.index,
+            bind:{
+                "value": {
+                    inside: item, to: 'selected'
+                },
+                "disabled" : {
+                    inside : item, to: "currentlyDisabled"
+                    }
+            },
+            value: item.selected
+        }/}
+
+    {/macro}
+
+    {macro footer()}
+        <div class="${data.skin.cssClassFooter}">
+            <div style="width:120px">
+                {@aria:Link {
+                    label : footerRes.selectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick : {
+                        fn : "selectAll",
+                        scope : moduleCtrl
+                    }
+                }/}
+            </div>
+            <span style="position:absolute;right:2px;text-align:right;">
+                {@aria:Link {
+                    label:footerRes.close,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "close",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+            <span>
+                {@aria:Link {
+                    label:footerRes.deselectAll,
+                    sclass : 'multiSelectFooter',
+                    onclick: {
+                        fn: "deselectAll",
+                        scope: moduleCtrl
+                    }
+                }/}
+            </span>
+        </div>
+    {/macro}
+
+{/Template}

--- a/test/benchmarks/at-html/input/small.tpl
+++ b/test/benchmarks/at-html/input/small.tpl
@@ -1,0 +1,26 @@
+{macro myMacro()}
+
+<!-- jhdjdsjvsdlkvjlfd -->
+{var a = 1 /}
+{@a:b sdfbhsdbjfsdhjsdfjl{}}
+
+	<![CDATA[
+{macro ahjbjd()}
+{/
+
+</
+
+<akhgbfdkjd mkhdllslslslslklkjsdfk${my}>
+
+]]>
+
+/**
+
+sdmsklsdlfsd
+*/
+
+
+{/@a:b}
+
+
+{/macro}

--- a/test/benchmarks/html/index.js
+++ b/test/benchmarks/html/index.js
@@ -1,0 +1,27 @@
+var fs = require('fs');
+
+
+
+
+function readSource(name) {
+	return fs.readFileSync(__dirname + '/input/' + name + '.html', 'utf-8');
+}
+
+
+var name = 'HTML';
+
+var parsers = [
+	{name: 'normal', parser: require('../../../app/node_modules/modes/html/parser').parser}
+];
+
+var inputs = [
+	{name: 'small', source: readSource('small')}
+	,
+	{name: 'big', source: bigSource = readSource('big')}
+];
+
+
+
+exports.name = name;
+exports.inputs = inputs;
+exports.parsers = parsers;

--- a/test/benchmarks/html/input/big.html
+++ b/test/benchmarks/html/input/big.html
@@ -1,0 +1,1663 @@
+
+
+
+<!DOCTYPE html>
+<html>
+  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# githubog: http://ogp.me/ns/fb/githubog#">
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>dmajda/pegjs</title>
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub" />
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
+    <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-114.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-144.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144.png" />
+    <link rel="logo" type="image/svg" href="https://github-media-downloads.s3.amazonaws.com/github-logo.svg" />
+    <meta property="og:image" content="https://github.global.ssl.fastly.net/images/modules/logos_page/Octocat.png">
+    <meta name="hostname" content="github-fe109-cp1-prd.iad.github.net">
+    <meta name="ruby" content="ruby 1.9.3p194-tcs-github-tcmalloc (0e75de19f8) [x86_64-linux]">
+    <link rel="assets" href="https://github.global.ssl.fastly.net/">
+    <link rel="conduit-xhr" href="https://ghconduit.com:25035/">
+    <link rel="xhr-socket" href="/_sockets" />
+
+
+
+    <meta name="msapplication-TileImage" content="/windows-tile.png" />
+    <meta name="msapplication-TileColor" content="#ffffff" />
+    <meta name="selected-link" value="repo_source" data-pjax-transient />
+    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="collector-cdn.github.com" name="octolytics-script-host" /><meta content="github" name="octolytics-app-id" /><meta content="5296F825:1FA6:2AE60753:526E5FCF" name="octolytics-dimension-request_id" /><meta content="2077669" name="octolytics-actor-id" /><meta content="ymeine" name="octolytics-actor-login" /><meta content="9535f2e888ef7e514bfdd55710a8df0a8417fc9e7d5036f9145e212c0fb8d512" name="octolytics-actor-hash" />
+
+
+
+
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+    <meta content="authenticity_token" name="csrf-param" />
+<meta content="J5Q8qJb+g9d+WWWbvoQ/qu2uH2RESq1csg6/Z8GBDW4=" name="csrf-token" />
+
+    <link href="https://github.global.ssl.fastly.net/assets/github-dfcee7b927f1abff62f05bf200dc06f74af4151e.css" media="all" rel="stylesheet" type="text/css" />
+    <link href="https://github.global.ssl.fastly.net/assets/github2-f6e49105f27058f9884f9899dfeb28d435f5d6a5.css" media="all" rel="stylesheet" type="text/css" />
+
+
+
+
+      <script src="https://github.global.ssl.fastly.net/assets/frameworks-848ce373d40d7414cbdab0864456e297f22ecf29.js" type="text/javascript"></script>
+      <script src="https://github.global.ssl.fastly.net/assets/github-4cec4c32b75cd2e2411d80b74bc0d065371d34bb.js" type="text/javascript"></script>
+
+      <meta http-equiv="x-pjax-version" content="b558cfcb387cb74833308fe2d7bb30af">
+
+        <meta property="og:title" content="pegjs"/>
+  <meta property="og:type" content="githubog:gitrepository"/>
+  <meta property="og:url" content="https://github.com/dmajda/pegjs"/>
+  <meta property="og:image" content="https://github.global.ssl.fastly.net/images/gravatars/gravatar-user-420.png"/>
+  <meta property="og:site_name" content="GitHub"/>
+  <meta property="og:description" content="pegjs - PEG.js: Parser Generator for JavaScript"/>
+
+  <meta name="description" content="pegjs - PEG.js: Parser Generator for JavaScript" />
+
+  <meta content="18821" name="octolytics-dimension-user_id" /><meta content="dmajda" name="octolytics-dimension-user_login" /><meta content="602604" name="octolytics-dimension-repository_id" /><meta content="dmajda/pegjs" name="octolytics-dimension-repository_nwo" /><meta content="true" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="602604" name="octolytics-dimension-repository_network_root_id" /><meta content="dmajda/pegjs" name="octolytics-dimension-repository_network_root_nwo" />
+  <link href="https://github.com/dmajda/pegjs/commits/master.atom" rel="alternate" title="Recent Commits to pegjs:master" type="application/atom+xml" />
+
+  </head>
+
+
+  <body class="logged_in  env-production windows vis-public">
+    <div class="wrapper">
+
+
+
+
+
+      <div class="header header-logged-in true">
+  <div class="container clearfix">
+
+    <a class="header-logo-invertocat" href="https://github.com/">
+  <span class="mega-octicon octicon-mark-github"></span>
+</a>
+
+
+    <a href="/notifications" class="notification-indicator tooltipped downwards" data-gotokey="n" title="You have no unread notifications">
+        <span class="mail-status all-read"></span>
+</a>
+
+      <div class="command-bar js-command-bar  in-repository">
+          <form accept-charset="UTF-8" action="/search" class="command-bar-form" id="top_search_form" method="get">
+
+<input type="text" data-hotkey=" s" name="q" id="js-command-bar-field" placeholder="Search or type a command" tabindex="1" autocapitalize="off"
+
+    data-username="ymeine"
+      data-repo="dmajda/pegjs"
+      data-branch="master"
+      data-sha="39c84f981448a25fb63da39a7eb8529c945f8e6e"
+  >
+
+    <input type="hidden" name="nwo" value="dmajda/pegjs" />
+
+    <div class="select-menu js-menu-container js-select-menu search-context-select-menu">
+      <span class="minibutton select-menu-button js-menu-target">
+        <span class="js-select-button">This repository</span>
+      </span>
+
+      <div class="select-menu-modal-holder js-menu-content js-navigation-container">
+        <div class="select-menu-modal">
+
+          <div class="select-menu-item js-navigation-item js-this-repository-navigation-item selected">
+            <span class="select-menu-item-icon octicon octicon-check"></span>
+            <input type="radio" class="js-search-this-repository" name="search_target" value="repository" checked="checked" />
+            <div class="select-menu-item-text js-select-button-text">This repository</div>
+          </div> <!-- /.select-menu-item -->
+
+          <div class="select-menu-item js-navigation-item js-all-repositories-navigation-item">
+            <span class="select-menu-item-icon octicon octicon-check"></span>
+            <input type="radio" name="search_target" value="global" />
+            <div class="select-menu-item-text js-select-button-text">All repositories</div>
+          </div> <!-- /.select-menu-item -->
+
+        </div>
+      </div>
+    </div>
+
+  <span class="octicon help tooltipped downwards" title="Show command bar help">
+    <span class="octicon octicon-question"></span>
+  </span>
+
+
+  <input type="hidden" name="ref" value="cmdform">
+
+</form>
+        <ul class="top-nav">
+          <li class="explore"><a href="/explore">Explore</a></li>
+            <li><a href="https://gist.github.com">Gist</a></li>
+            <li><a href="/blog">Blog</a></li>
+          <li><a href="https://help.github.com">Help</a></li>
+        </ul>
+      </div>
+
+
+
+
+  <ul id="user-links">
+    <li>
+      <a href="/ymeine" class="name">
+        <img height="20" src="https://1.gravatar.com/avatar/381441499d2134da8f9d940898d99e6f?d=https%3A%2F%2Fidenticons.github.com%2Fbe04dbf99a923c527b93f664a489bca5.png&amp;r=x&amp;s=140" width="20" /> ymeine
+      </a>
+    </li>
+
+      <li>
+        <a href="/new" id="new_repo" class="tooltipped downwards" title="Create a new repo" aria-label="Create a new repo">
+          <span class="octicon octicon-repo-create"></span>
+        </a>
+      </li>
+
+      <li>
+        <a href="/settings/profile" id="account_settings"
+          class="tooltipped downwards"
+          aria-label="Account settings "
+          title="Account settings ">
+          <span class="octicon octicon-tools"></span>
+        </a>
+      </li>
+      <li>
+        <a class="tooltipped downwards" href="/logout" data-method="post" id="logout" title="Sign out" aria-label="Sign out">
+          <span class="octicon octicon-log-out"></span>
+        </a>
+      </li>
+
+  </ul>
+
+<div class="js-new-dropdown-contents hidden">
+
+
+<ul class="dropdown-menu">
+  <li>
+    <a href="/new"><span class="octicon octicon-repo-create"></span> New repository</a>
+  </li>
+  <li>
+    <a href="/organizations/new"><span class="octicon octicon-organization"></span> New organization</a>
+  </li>
+
+
+
+    <li class="section-title">
+      <span title="dmajda/pegjs">This repository</span>
+    </li>
+      <li>
+        <a href="/dmajda/pegjs/issues/new"><span class="octicon octicon-issue-opened"></span> New issue</a>
+      </li>
+</ul>
+
+</div>
+
+
+
+  </div>
+</div>
+
+
+
+
+
+
+
+
+          <div class="site" itemscope itemtype="http://schema.org/WebPage">
+
+    <div class="pagehead repohead instapaper_ignore readability-menu">
+      <div class="container">
+
+
+<ul class="pagehead-actions">
+
+    <li class="subscription">
+      <form accept-charset="UTF-8" action="/notifications/subscribe" class="js-social-container" data-autosubmit="true" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="authenticity_token" type="hidden" value="J5Q8qJb+g9d+WWWbvoQ/qu2uH2RESq1csg6/Z8GBDW4=" /></div>  <input id="repository_id" name="repository_id" type="hidden" value="602604" />
+
+    <div class="select-menu js-menu-container js-select-menu">
+      <a class="social-count js-social-count" href="/dmajda/pegjs/watchers">
+        34
+      </a>
+      <span class="minibutton select-menu-button with-count js-menu-target" role="button" tabindex="0">
+        <span class="js-select-button">
+          <span class="octicon octicon-eye-watch"></span>
+          Watch
+        </span>
+      </span>
+
+      <div class="select-menu-modal-holder">
+        <div class="select-menu-modal subscription-menu-modal js-menu-content">
+          <div class="select-menu-header">
+            <span class="select-menu-title">Notification status</span>
+            <span class="octicon octicon-remove-close js-menu-close"></span>
+          </div> <!-- /.select-menu-header -->
+
+          <div class="select-menu-list js-navigation-container" role="menu">
+
+            <div class="select-menu-item js-navigation-item selected" role="menuitem" tabindex="0">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <div class="select-menu-item-text">
+                <input checked="checked" id="do_included" name="do" type="radio" value="included" />
+                <h4>Not watching</h4>
+                <span class="description">You only receive notifications for discussions in which you participate or are @mentioned.</span>
+                <span class="js-select-button-text hidden-select-button-text">
+                  <span class="octicon octicon-eye-watch"></span>
+                  Watch
+                </span>
+              </div>
+            </div> <!-- /.select-menu-item -->
+
+            <div class="select-menu-item js-navigation-item " role="menuitem" tabindex="0">
+              <span class="select-menu-item-icon octicon octicon octicon-check"></span>
+              <div class="select-menu-item-text">
+                <input id="do_subscribed" name="do" type="radio" value="subscribed" />
+                <h4>Watching</h4>
+                <span class="description">You receive notifications for all discussions in this repository.</span>
+                <span class="js-select-button-text hidden-select-button-text">
+                  <span class="octicon octicon-eye-unwatch"></span>
+                  Unwatch
+                </span>
+              </div>
+            </div> <!-- /.select-menu-item -->
+
+            <div class="select-menu-item js-navigation-item " role="menuitem" tabindex="0">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <div class="select-menu-item-text">
+                <input id="do_ignore" name="do" type="radio" value="ignore" />
+                <h4>Ignoring</h4>
+                <span class="description">You do not receive any notifications for discussions in this repository.</span>
+                <span class="js-select-button-text hidden-select-button-text">
+                  <span class="octicon octicon-mute"></span>
+                  Stop ignoring
+                </span>
+              </div>
+            </div> <!-- /.select-menu-item -->
+
+          </div> <!-- /.select-menu-list -->
+
+        </div> <!-- /.select-menu-modal -->
+      </div> <!-- /.select-menu-modal-holder -->
+    </div> <!-- /.select-menu -->
+
+</form>
+    </li>
+
+  <li>
+
+<div class="js-toggler-container js-social-container starring-container on">
+  <a href="/dmajda/pegjs/unstar" class="minibutton with-count js-toggler-target star-button starred upwards" title="Unstar this repo" data-remote="true" data-method="post" rel="nofollow">
+    <span class="octicon octicon-star-delete"></span><span class="text">Unstar</span>
+  </a>
+  <a href="/dmajda/pegjs/star" class="minibutton with-count js-toggler-target star-button unstarred upwards" title="Star this repo" data-remote="true" data-method="post" rel="nofollow">
+    <span class="octicon octicon-star"></span><span class="text">Star</span>
+  </a>
+  <a class="social-count js-social-count" href="/dmajda/pegjs/stargazers">696</a>
+</div>
+
+  </li>
+
+
+        <li>
+          <a href="/dmajda/pegjs/fork" class="minibutton with-count js-toggler-target fork-button lighter upwards" title="Fork this repo" rel="facebox nofollow">
+            <span class="octicon octicon-git-branch-create"></span><span class="text">Fork</span>
+          </a>
+          <a href="/dmajda/pegjs/network" class="social-count">120</a>
+        </li>
+
+
+</ul>
+
+        <h1 itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="entry-title public">
+          <span class="repo-label"><span>public</span></span>
+          <span class="mega-octicon octicon-repo"></span>
+          <span class="author">
+            <a href="/dmajda" class="url fn" itemprop="url" rel="author"><span itemprop="title">dmajda</span></a>
+          </span>
+          <span class="repohead-name-divider">/</span>
+          <strong><a href="/dmajda/pegjs" class="js-current-repository js-repo-home-link">pegjs</a></strong>
+
+          <span class="page-context-loader">
+            <img alt="Octocat-spinner-32" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+          </span>
+
+        </h1>
+      </div><!-- /.container -->
+    </div><!-- /.repohead -->
+
+    <div class="container">
+
+      <div class="repository-with-sidebar repo-container with-full-navigation">
+
+        <div class="repository-sidebar">
+
+
+<div class="sunken-menu vertical-right repo-nav js-repo-nav js-repository-container-pjax js-octicon-loaders">
+  <div class="sunken-menu-contents">
+    <ul class="sunken-menu-group">
+      <li class="tooltipped leftwards" title="Code">
+        <a href="/dmajda/pegjs" aria-label="Code" class="selected js-selected-navigation-item sunken-menu-item" data-gotokey="c" data-pjax="true" data-selected-links="repo_source repo_downloads repo_commits repo_tags repo_branches /dmajda/pegjs">
+          <span class="octicon octicon-code"></span> <span class="full-word">Code</span>
+          <img alt="Octocat-spinner-32" class="mini-loader" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>      </li>
+
+        <li class="tooltipped leftwards" title="Issues">
+          <a href="/dmajda/pegjs/issues" aria-label="Issues" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-gotokey="i" data-selected-links="repo_issues /dmajda/pegjs/issues">
+            <span class="octicon octicon-issue-opened"></span> <span class="full-word">Issues</span>
+            <span class='counter'>57</span>
+            <img alt="Octocat-spinner-32" class="mini-loader" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>        </li>
+
+      <li class="tooltipped leftwards" title="Pull Requests"><a href="/dmajda/pegjs/pulls" aria-label="Pull Requests" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-gotokey="p" data-selected-links="repo_pulls /dmajda/pegjs/pulls">
+            <span class="octicon octicon-git-pull-request"></span> <span class="full-word">Pull Requests</span>
+            <span class='counter'>11</span>
+            <img alt="Octocat-spinner-32" class="mini-loader" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>      </li>
+
+
+        <li class="tooltipped leftwards" title="Wiki">
+          <a href="/dmajda/pegjs/wiki" aria-label="Wiki" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="repo_wiki /dmajda/pegjs/wiki">
+            <span class="octicon octicon-book"></span> <span class="full-word">Wiki</span>
+            <img alt="Octocat-spinner-32" class="mini-loader" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>        </li>
+    </ul>
+    <div class="sunken-menu-separator"></div>
+    <ul class="sunken-menu-group">
+
+      <li class="tooltipped leftwards" title="Pulse">
+        <a href="/dmajda/pegjs/pulse" aria-label="Pulse" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="pulse /dmajda/pegjs/pulse">
+          <span class="octicon octicon-pulse"></span> <span class="full-word">Pulse</span>
+          <img alt="Octocat-spinner-32" class="mini-loader" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>      </li>
+
+      <li class="tooltipped leftwards" title="Graphs">
+        <a href="/dmajda/pegjs/graphs" aria-label="Graphs" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="repo_graphs repo_contributors /dmajda/pegjs/graphs">
+          <span class="octicon octicon-graph"></span> <span class="full-word">Graphs</span>
+          <img alt="Octocat-spinner-32" class="mini-loader" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>      </li>
+
+      <li class="tooltipped leftwards" title="Network">
+        <a href="/dmajda/pegjs/network" aria-label="Network" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-selected-links="repo_network /dmajda/pegjs/network">
+          <span class="octicon octicon-git-branch"></span> <span class="full-word">Network</span>
+          <img alt="Octocat-spinner-32" class="mini-loader" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>      </li>
+    </ul>
+
+
+  </div>
+</div>
+
+            <div class="only-with-full-nav">
+
+
+
+
+<div class="clone-url open"
+  data-protocol-type="http"
+  data-url="/users/set_protocol?protocol_selector=http&amp;protocol_type=clone">
+  <h3><strong>HTTPS</strong> clone URL</h3>
+  <div class="clone-url-box">
+    <input type="text" class="clone js-url-field"
+           value="https://github.com/dmajda/pegjs.git" readonly="readonly">
+
+    <span class="js-zeroclipboard url-box-clippy minibutton zeroclipboard-button" data-clipboard-text="https://github.com/dmajda/pegjs.git" data-copied-hint="copied!" title="copy to clipboard"><span class="octicon octicon-clippy"></span></span>
+  </div>
+</div>
+
+
+
+<div class="clone-url "
+  data-protocol-type="ssh"
+  data-url="/users/set_protocol?protocol_selector=ssh&amp;protocol_type=clone">
+  <h3><strong>SSH</strong> clone URL</h3>
+  <div class="clone-url-box">
+    <input type="text" class="clone js-url-field"
+           value="git@github.com:dmajda/pegjs.git" readonly="readonly">
+
+    <span class="js-zeroclipboard url-box-clippy minibutton zeroclipboard-button" data-clipboard-text="git@github.com:dmajda/pegjs.git" data-copied-hint="copied!" title="copy to clipboard"><span class="octicon octicon-clippy"></span></span>
+  </div>
+</div>
+
+
+
+<div class="clone-url "
+  data-protocol-type="subversion"
+  data-url="/users/set_protocol?protocol_selector=subversion&amp;protocol_type=clone">
+  <h3><strong>Subversion</strong> checkout URL</h3>
+  <div class="clone-url-box">
+    <input type="text" class="clone js-url-field"
+           value="https://github.com/dmajda/pegjs" readonly="readonly">
+
+    <span class="js-zeroclipboard url-box-clippy minibutton zeroclipboard-button" data-clipboard-text="https://github.com/dmajda/pegjs" data-copied-hint="copied!" title="copy to clipboard"><span class="octicon octicon-clippy"></span></span>
+  </div>
+</div>
+
+
+<p class="clone-options">You can clone with
+      <a href="#" class="js-clone-selector" data-protocol="http">HTTPS</a>,
+      <a href="#" class="js-clone-selector" data-protocol="ssh">SSH</a>,
+      or <a href="#" class="js-clone-selector" data-protocol="subversion">Subversion</a>.
+  <span class="octicon help tooltipped upwards" title="Get help on which URL is right for you.">
+    <a href="https://help.github.com/articles/which-remote-url-should-i-use">
+    <span class="octicon octicon-question"></span>
+    </a>
+  </span>
+</p>
+
+
+  <a href="github-windows://openRepo/https://github.com/dmajda/pegjs" class="minibutton sidebar-button">
+    <span class="octicon octicon-device-desktop"></span>
+    Clone in Desktop
+  </a>
+
+              <a href="/dmajda/pegjs/archive/master.zip"
+                 class="minibutton sidebar-button"
+                 title="Download this repository as a zip file"
+                 rel="nofollow">
+                <span class="octicon octicon-cloud-download"></span>
+                Download ZIP
+              </a>
+            </div>
+        </div><!-- /.repository-sidebar -->
+
+        <div id="js-repo-pjax-container" class="repository-content context-loader-container" data-pjax-container>
+
+
+<span id="js-show-full-navigation"></span>
+
+<div class="repository-meta js-details-container ">
+    <div class="repository-description js-details-show">
+      <p>PEG.js: Parser Generator for JavaScript</p>
+    </div>
+
+    <div class="repository-website js-details-show">
+      <p><a href="http://pegjs.majda.cz/" rel="nofollow">http://pegjs.majda.cz/</a></p>
+    </div>
+
+
+</div>
+
+<div class="capped-box overall-summary ">
+
+  <div class="stats-switcher-viewport js-stats-switcher-viewport">
+
+    <ul class="numbers-summary">
+      <li class="commits">
+        <a data-pjax href="/dmajda/pegjs/commits/master">
+          <span class="num">
+            <span class="octicon octicon-history"></span>
+            547
+          </span>
+          commits
+        </a>
+      </li>
+      <li>
+        <a data-pjax href="/dmajda/pegjs/branches">
+          <span class="num">
+            <span class="octicon octicon-git-branch"></span>
+            2
+          </span>
+          branches
+        </a>
+      </li>
+
+      <li>
+        <a data-pjax href="/dmajda/pegjs/releases">
+          <span class="num">
+            <span class="octicon octicon-tag"></span>
+            12
+          </span>
+          releases
+        </a>
+      </li>
+
+      <li>
+
+  <a href="/dmajda/pegjs/graphs/contributors">
+    <span class="num">
+      <span class="octicon octicon-organization"></span>
+      8
+    </span>
+    contributors
+  </a>
+      </li>
+    </ul>
+
+      <div class="repository-lang-stats">
+        <ol class="repository-lang-stats-numbers">
+          <li>
+              <a href="/dmajda/pegjs/search?l=javascript">
+                <span class="color-block language-color" style="background-color:#f15501;"></span>
+                <span class="lang">JavaScript</span>
+                <span class="percent">76.1%</span>
+              </a>
+          </li>
+          <li>
+              <a href="/dmajda/pegjs/search?l=css">
+                <span class="color-block language-color" style="background-color:#1f085e;"></span>
+                <span class="lang">CSS</span>
+                <span class="percent">23.9%</span>
+              </a>
+          </li>
+        </ol>
+      </div>
+  </div>
+
+</div>
+
+  <a href="#"
+     class="repository-lang-stats-graph js-toggle-lang-stats tooltipped downwards"
+     title="Show language statistics"
+     style="background-color:#1f085e">
+  <span class="language-color" style="width:76.1%; background-color:#f15501;" itemprop="keywords">JavaScript</span><span class="language-color" style="width:23.9%; background-color:#1f085e;" itemprop="keywords">CSS</span>
+  </a>
+
+
+
+
+<div class="file-navigation in-mid-page">
+    <a href="/dmajda/pegjs/compare" aria-label="Compare, review, create a pull request" class="minibutton compact primary tooltipped downwards" title="Compare &amp; review" data-pjax>
+      <span class="octicon octicon-git-compare"></span>
+    </a>
+
+
+
+
+<div class="select-menu js-menu-container js-select-menu" >
+  <span class="minibutton select-menu-button js-menu-target" data-hotkey="w"
+    data-master-branch="master"
+    data-ref="master"
+    role="button" aria-label="Switch branches or tags" tabindex="0">
+    <span class="octicon octicon-git-branch"></span>
+    <i>branch:</i>
+    <span class="js-select-button">master</span>
+  </span>
+
+  <div class="select-menu-modal-holder js-menu-content js-navigation-container" data-pjax>
+
+    <div class="select-menu-modal">
+      <div class="select-menu-header">
+        <span class="select-menu-title">Switch branches/tags</span>
+        <span class="octicon octicon-remove-close js-menu-close"></span>
+      </div> <!-- /.select-menu-header -->
+
+      <div class="select-menu-filters">
+        <div class="select-menu-text-filter">
+          <input type="text" aria-label="Filter branches/tags" id="context-commitish-filter-field" class="js-filterable-field js-navigation-enable" placeholder="Filter branches/tags">
+        </div>
+        <div class="select-menu-tabs">
+          <ul>
+            <li class="select-menu-tab">
+              <a href="#" data-tab-filter="branches" class="js-select-menu-tab">Branches</a>
+            </li>
+            <li class="select-menu-tab">
+              <a href="#" data-tab-filter="tags" class="js-select-menu-tab">Tags</a>
+            </li>
+          </ul>
+        </div><!-- /.select-menu-tabs -->
+      </div><!-- /.select-menu-filters -->
+
+      <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-tab-filter="branches">
+
+        <div data-filterable-for="context-commitish-filter-field" data-filterable-type="substring">
+
+
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.5.x"
+                 data-name="0.5.x"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.5.x">0.5.x</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item selected">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/master"
+                 data-name="master"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="master">master</a>
+            </div> <!-- /.select-menu-item -->
+        </div>
+
+          <div class="select-menu-no-results">Nothing to show</div>
+      </div> <!-- /.select-menu-list -->
+
+      <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-tab-filter="tags">
+        <div data-filterable-for="context-commitish-filter-field" data-filterable-type="substring">
+
+
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/v0.7.0"
+                 data-name="v0.7.0"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="v0.7.0">v0.7.0</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/semver"
+                 data-name="semver"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="semver">semver</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.6.2"
+                 data-name="0.6.2"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.6.2">0.6.2</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.6.1"
+                 data-name="0.6.1"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.6.1">0.6.1</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.6.0"
+                 data-name="0.6.0"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.6.0">0.6.0</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.5.1"
+                 data-name="0.5.1"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.5.1">0.5.1</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.5"
+                 data-name="0.5"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.5">0.5</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.4"
+                 data-name="0.4"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.4">0.4</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.3"
+                 data-name="0.3"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.3">0.3</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.2.1"
+                 data-name="0.2.1"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.2.1">0.2.1</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.2"
+                 data-name="0.2"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.2">0.2</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/dmajda/pegjs/tree/0.1"
+                 data-name="0.1"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text js-select-button-text css-truncate-target"
+                 title="0.1">0.1</a>
+            </div> <!-- /.select-menu-item -->
+        </div>
+
+        <div class="select-menu-no-results">Nothing to show</div>
+      </div> <!-- /.select-menu-list -->
+
+    </div> <!-- /.select-menu-modal -->
+  </div> <!-- /.select-menu-modal-holder -->
+</div> <!-- /.select-menu -->
+
+
+  <div class="breadcrumb"><span class='repo-root js-repo-root'><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/dmajda/pegjs" data-branch="master" data-direction="back" data-pjax="true" itemscope="url"><span itemprop="title">pegjs</span></a></span></span><span class="separator"> / </span><form action="/dmajda/pegjs/new/master" class="js-new-blob-form tooltipped rightwards new-file-link" method="post" title="Fork this project and create a new file"><span aria-label="Fork this project and create a new file" class="js-new-blob-submit octicon octicon-file-add" data-test-id="create-new-git-file" role="button"></span></form></div>
+</div>
+
+
+
+<a href="/dmajda/pegjs/find/master"
+  data-hotkey="t" class="js-show-file-finder" style="display:none" data-pjax>Show File Finder</a>
+<div class="bubble files-bubble">
+  <table class="files" data-pjax>
+    <thead>
+
+
+  <div class="commit commit-tease js-details-container" >
+    <p class="commit-title ">
+        <a href="/dmajda/pegjs/commit/5312e124cde69d328d6de86809fd68d1a6b1399e" class="message" data-pjax="true" title="Fix object literal formatting in generated code">Fix object literal formatting in generated code</a>
+
+    </p>
+    <div class="commit-meta">
+      <span class="js-zeroclipboard zeroclipboard-link" data-clipboard-text="5312e124cde69d328d6de86809fd68d1a6b1399e" data-copied-hint="copied!" title="Copy SHA"><span class="octicon octicon-clippy"></span></span>
+      <a href="/dmajda/pegjs/commit/5312e124cde69d328d6de86809fd68d1a6b1399e" class="sha-block" data-pjax>latest commit <span class="sha">5312e124cd</span></a>
+
+      <div class="authorship">
+        <img class="gravatar" height="20" src="https://2.gravatar.com/avatar/ebe96461709771a430da9c7c58f9ae5f?d=https%3A%2F%2Fidenticons.github.com%2Ffb945b3067434474ba269b604525ca02.png&amp;s=140" width="20" />
+        <span class="author-name"><a href="/dmajda" data-skip-pjax="true" rel="author">dmajda</a></span>
+        authored <time class="js-relative-date updated" datetime="2013-09-04T08:47:07-07:00" title="2013-09-04 08:47:07">September 04, 2013</time>
+
+      </div>
+    </div>
+  </div>
+    </thead>
+
+
+<tbody class=""
+  data-url="/dmajda/pegjs/file-list/master">
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-directory"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/tree/master/benchmark" class="js-directory-link" id="07978586e47c8709a63e895fbf3c3c7d-d7c8938414ff1605bbc5fbfc840bdf28044ce596" title="benchmark">benchmark</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/fe1ca481abc7ee5a499a26eed226f06c9c2024d5" class="message" data-pjax="true" title="Code generator rewrite
+
+This is a complete rewrite of the PEG.js code generator. Its goals are:
+
+  1. Allow optimizing the generated parser code for code size as well as
+     for parsing speed.
+
+  2. Prepare ground for future optimizations and big features (like
+     incremental parsing).
+
+  2. Replace the old template-based code-generation system with
+     something more lightweight and flexible.
+
+  4. General code cleanup (structure, style, variable names, ...).
+
+New Architecture
+----------------
+
+The new code generator consists of two steps:
+
+  * Bytecode generator -- produces bytecode for an abstract virtual
+    machine
+
+  * JavaScript generator -- produces JavaScript code based on the
+    bytecode
+
+The abstract virtual machine is stack-based. Originally I wanted to make
+it register-based, but it turned out that all the code related to it
+would be more complex and the bytecode itself would be longer (because
+of explicit register specifications in instructions). The only downsides
+of the stack-based approach seem to be few small inefficiencies (see
+e.g. the |NIP| instruction), which seem to be insignificant.
+
+The new generator allows optimizing for parsing speed or code size (you
+can choose using the |optimize| option of the |PEG.buildParser| method
+or the --optimize/-o option on the command-line).
+
+When optimizing for size, the JavaScript generator emits the bytecode
+together with its constant table and a generic bytecode interpreter.
+Because the interpreter is small and the bytecode and constant table
+grow only slowly with size of the grammar, the resulting parser is also
+small.
+
+When optimizing for speed, the JavaScript generator just compiles the
+bytecode into JavaScript. The generated code is relatively efficient, so
+the resulting parser is fast.
+
+Internal Identifiers
+--------------------
+
+As a small bonus, all internal identifiers visible to user code in the
+initializer, actions and predicates are prefixed by |peg$|. This lowers
+the chance that identifiers in user code will conflict with the ones
+from PEG.js. It also makes using any internals in user code ugly, which
+is a good thing. This solves GH-92.
+
+Performance
+-----------
+
+The new code generator improved parsing speed and parser code size
+significantly. The generated parsers are now:
+
+  * 39% faster when optimizing for speed
+
+  * 69% smaller when optimizing for size (without minification)
+
+  * 31% smaller when optimizing for size (with minification)
+
+(Parsing speed was measured using the |benchmark/run| script. Code size
+was measured by generating parsers for examples in the |examples|
+directory and adding up the file sizes. Minification was done by |uglify
+--ascii| in version 1.3.4.)
+
+Final Note
+----------
+
+This is just a beginning! The new code generator lays a foundation upon
+which many optimizations and improvements can (and will) be made.
+
+Stay tuned :-)">Code generator rewrite</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-01-01T07:38:09-08:00" title="2013-01-01 07:38:09">January 01, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-directory"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/tree/master/bin" class="js-directory-link" id="c1111bd512b29e821b120b86446026b8-402d1bf3cf830ebf7f7501b8047e4d4fe2e7544e" title="bin">bin</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/851681d66324a5aed3e9e4899502ac6c2f9afbeb" class="message" data-pjax="true" title="Implement the --extra-options and --extra-options-file options
+
+These are mainly useful to pass additional options to plugins.">Implement the --extra-options and --extra-options-file options</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-01-20T01:11:08-08:00" title="2013-01-20 01:11:08">January 20, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-directory"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/tree/master/examples" class="js-directory-link" id="bfebe34154a0dfd9fc7b447fc9ed74e9-6d25a6515f86897acd4cb2cd704955dfa1ef0843" title="examples">examples</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/f3d392bd1cb3bd6a656e656e6919817178d9ab65" class="message" data-pjax="true" title="JavaScript example: Fix handling of elided elements in array literals
+
+JavaScript allows one to skip (elide) elements in array literals. It
+also allows a trailing comma, which doesn&#39;t imply an element elision.
+
+For example, an array literal:
+
+  [,,,]
+
+contains three elided elements (one before each comma) and a trailing
+comma.
+
+Example JavaScript parser handled elided elements incorrectly and just
+threw them away. This commit fixes this behvior and inserts |null| in
+the AST for each elided element. This is in line with how SpiderMonkey&#39;s
+JavaScript parser (the |Reflect.parse| API), Esprima and Acorn behave.
+
+Based on a patch by @fpirsch:
+
+  https://github.com/dmajda/pegjs/pull/177">JavaScript example: Fix handling of elided elements in array literals</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-08-31T02:02:00-07:00" title="2013-08-31 02:02:00">August 31, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-directory"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/tree/master/lib" class="js-directory-link" id="e8acc63b1e238f3255c900eed37254b8-878744c854d13697ca6913390270e6b424df1e2c" title="lib">lib</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/5312e124cde69d328d6de86809fd68d1a6b1399e" class="message" data-pjax="true" title="Fix object literal formatting in generated code">Fix object literal formatting in generated code</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-09-04T08:47:07-07:00" title="2013-09-04 08:47:07">September 04, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-directory"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/tree/master/spec" class="js-directory-link" id="b979c2934ac0b4ba3f08dabfdd1b2299-dc4dd6adad4fc0c3e2e5381e6d35b0a6f9de4810" title="spec">spec</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/7dc9a9ae76c73c0c10a1598e870a8a8d39af4569" class="message" data-pjax="true" title="Upgrade jasmine and jasmine-node">Upgrade jasmine and jasmine-node</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-08-22T00:07:19-07:00" title="2013-08-22 00:07:19">August 22, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-directory"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/tree/master/src" class="js-directory-link" id="25d902c24283ab8cfbac54dfa101ad31-4c15ce2d25b51cf10117da652ca88380f518c06e" title="src">src</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/5942988f66ce79d4784348831b9fb0105ca0e5bf" class="message" data-pjax="true" title="Remove the |startRule| property from the AST
+
+It&#39;s redundant.">Remove the |startRule| property from the AST</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-01-06T01:21:48-08:00" title="2013-01-06 01:21:48">January 06, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-directory"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/tree/master/tools" class="js-directory-link" id="4a931512ce65bdc9ca6808adf92d8783-e9fc899debb244caa22870811cb72a7c849cd980" title="tools">tools</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/da9ab1bf17cd860c8231feb8ae435497c786965d" class="message" data-pjax="true" title="Remove &quot;make build&quot; from tools/impact
+
+There is no &quot;build&quot; target anymore.
+
+This was forgotten in 0519d7e3ce2f64dbe40b85240fbf96e3c3c80f01.">Remove "make build" from tools/impact</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2012-12-02T04:04:57-08:00" title="2012-12-02 04:04:57">December 02, 2012</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/.gitignore" class="js-directory-link" id="a084b794bc0759e7a6b77810e01874f2-0b2ce234c0092a494d624a368e8c9b619ed2f3dd" title=".gitignore">.gitignore</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/ee1a0b5810c8369c76b4d55752862674ce46c381" class="message" data-pjax="true" title="Add compiled examples to .gitignore
+
+Based on patch by Pavel Lang (GH-96).">Add compiled examples to .gitignore</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2012-11-10T06:21:36-08:00" title="2012-11-10 06:21:36">November 10, 2012</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/.jshintrc" class="js-directory-link" id="4d5aa81bf4f18104bb6ea53a8b5d1f43-587d66f0629399497618a29f254f368be91f0b69" title=".jshintrc">.jshintrc</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/50be1081e075937bb54cc2b2d98bb7f14d02faa8" class="message" data-pjax="true" title="Sort JSHint options alphabetically">Sort JSHint options alphabetically</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2011-09-18T07:55:27-07:00" title="2011-09-18 07:55:27">September 18, 2011</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/.travis.yml" class="js-directory-link" id="354f30a63fb0907d4ad57269548329e3-895dbd36234210374d68a0f020b2d6e7abf736fa" title=".travis.yml">.travis.yml</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/12398ada9a4e45f7d6ceeef6c8e73b34aac7d070" class="message" data-pjax="true" title="Implement Travis CI integration">Implement Travis CI integration</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2012-10-28T08:01:13-07:00" title="2012-10-28 08:01:13">October 28, 2012</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/CHANGELOG" class="js-directory-link" id="d3bb3391c79904494c60ee2ac2f33070-52d2bf2322651bb519c0bbf0291d966b3236b57b" title="CHANGELOG">CHANGELOG</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/4e04acafa35cd5e12874ef41c5b57f75be5f4a92" class="message" data-pjax="true" title="Update CHANGELOG">Update CHANGELOG</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2012-04-18T01:26:05-07:00" title="2012-04-18 01:26:05">April 18, 2012</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/LICENSE" class="js-directory-link" id="9879d6db96fd29134fc802214163b95a-8a870ab41a2f7f1283744c2ffcb2d67191b5d40c" title="LICENSE">LICENSE</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/d28324306cfe62e2464679ab2788d8ff8a9ca944" class="message" data-pjax="true" title="LICENSE: Update copyright years">LICENSE: Update copyright years</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2012-04-16T05:36:51-07:00" title="2012-04-16 05:36:51">April 16, 2012</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/Makefile" class="js-directory-link" id="b67911656ef5d18c4ae36cb6741b7965-2d4e65b567a17a6f77ad81a11a7394abc0ceba19" title="Makefile">Makefile</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/3b3798fa39ef3fa880d275fce306c9575d8c2e1a" class="message" data-pjax="true" title="Merge lib/compiler/passes.js into lib/compiler.js
+
+It didn&#39;t make sense to have the passes in a separate file.">Merge lib/compiler/passes.js into lib/compiler.js</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-01-11T11:25:49-08:00" title="2013-01-11 11:25:49">January 11, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/README.md" class="js-directory-link" id="04c6e90faac2675aa89e2176d2eec7d8-aa1d36aaa6b6b9332084ac1799d108b343f235d6" title="README.md">README.md</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/35a4b35f94fd7e2ff9221ca7752d36119a2366cb" class="message" data-pjax="true" title="Add initializer example in README.md">Add initializer example in README.md</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-08-02T08:31:37-07:00" title="2013-08-02 08:31:37">August 02, 2013</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/VERSION" class="js-directory-link" id="021321e8c168ba3ae39ce3a2e7b3ec87-faef31a4357c48d6e4c55e84c8be8e3bc9055e20" title="VERSION">VERSION</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/6091e4426bb8c35b738302b6ce4d2627aec6d04f" class="message" data-pjax="true" title="Update version to 0.7.0">Update version to 0.7.0</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2012-04-18T01:31:18-07:00" title="2012-04-18 01:31:18">April 18, 2012</time></span></td>
+    </tr>
+    <tr>
+      <td class="icon">
+        <span class="octicon octicon-file-text"></span>
+        <img alt="Octocat-spinner-32" class="spinner" height="16" src="https://github.global.ssl.fastly.net/images/spinners/octocat-spinner-32.gif" width="16" />
+      </td>
+      <td class="content">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/blob/master/package.json" class="js-directory-link" id="b9cfc7f2cdf78a7f4b91a753d10865a2-fa2fcfb51c0b387a1f9e9bacdb6556c2f65df0c9" title="package.json">package.json</a></span>
+      </td>
+      <td class="message">
+        <span class="css-truncate css-truncate-target"><a href="/dmajda/pegjs/commit/7dc9a9ae76c73c0c10a1598e870a8a8d39af4569" class="message" data-pjax="true" title="Upgrade jasmine and jasmine-node">Upgrade jasmine and jasmine-node</a></span>
+      </td>
+      <td class="age"><span class="css-truncate css-truncate-target"><time class="js-relative-date" datetime="2013-08-22T00:07:19-07:00" title="2013-08-22 00:07:19">August 22, 2013</time></span></td>
+    </tr>
+</tbody>
+
+  </table>
+</div>
+
+  <div id="readme" class="clearfix announce instapaper_body md">
+    <span class="name"><span class="octicon octicon-book"></span> README.md</span><article class="markdown-body entry-content" itemprop="mainContentOfPage"><h1>
+<a name="pegjs" class="anchor" href="#pegjs"><span class="octicon octicon-link"></span></a>PEG.js</h1>
+
+<p>PEG.js is a simple parser generator for JavaScript that produces fast parsers
+with excellent error reporting. You can use it to process complex data or
+computer languages and build transformers, interpreters, compilers and other
+tools easily.</p>
+
+<h2>
+<a name="features" class="anchor" href="#features"><span class="octicon octicon-link"></span></a>Features</h2>
+
+<ul>
+<li>Simple and expressive grammar syntax</li>
+<li>Integrates both lexical and syntactical analysis</li>
+<li>Parsers have excellent error reporting out of the box</li>
+<li>Based on <a href="http://en.wikipedia.org/wiki/Parsing_expression_grammar">parsing expression
+grammar</a> formalism
+— more powerful than traditional LL(*k*) and LR(*k*) parsers</li>
+<li>Usable <a href="http://pegjs.majda.cz/online">from your browser</a>, from the command
+line, or via JavaScript API</li>
+</ul><h2>
+<a name="getting-started" class="anchor" href="#getting-started"><span class="octicon octicon-link"></span></a>Getting Started</h2>
+
+<p><a href="http://pegjs.majda.cz/online">Online version</a> is the easiest way to generate a
+parser. Just enter your grammar, try parsing few inputs, and download generated
+parser code.</p>
+
+<h2>
+<a name="installation" class="anchor" href="#installation"><span class="octicon octicon-link"></span></a>Installation</h2>
+
+<h3>
+<a name="nodejs" class="anchor" href="#nodejs"><span class="octicon octicon-link"></span></a>Node.js</h3>
+
+<p>To use the <code>pegjs</code> command, install PEG.js globally:</p>
+
+<pre><code>$ npm install -g pegjs
+</code></pre>
+
+<p>To use the JavaScript API, install PEG.js locally:</p>
+
+<pre><code>$ npm install pegjs
+</code></pre>
+
+<p>If you need both the <code>pegjs</code> command and the JavaScript API, install PEG.js both
+ways.</p>
+
+<h3>
+<a name="browser" class="anchor" href="#browser"><span class="octicon octicon-link"></span></a>Browser</h3>
+
+<p><a href="http://pegjs.majda.cz/#download">Download</a> the PEG.js library (regular or
+minified version).</p>
+
+<h2>
+<a name="generating-a-parser" class="anchor" href="#generating-a-parser"><span class="octicon octicon-link"></span></a>Generating a Parser</h2>
+
+<p>PEG.js generates parser from a grammar that describes expected input and can
+specify what the parser returns (using semantic actions on matched parts of the
+input). Generated parser itself is a JavaScript object with a simple API.</p>
+
+<h3>
+<a name="command-line" class="anchor" href="#command-line"><span class="octicon octicon-link"></span></a>Command Line</h3>
+
+<p>To generate a parser from your grammar, use the <code>pegjs</code> command:</p>
+
+<pre><code>$ pegjs arithmetics.pegjs
+</code></pre>
+
+<p>This writes parser source code into a file with the same name as the grammar
+file but with “.js” extension. You can also specify the output file explicitly:</p>
+
+<pre><code>$ pegjs arithmetics.pegjs arithmetics-parser.js
+</code></pre>
+
+<p>If you omit both input and ouptut file, standard input and output are used.</p>
+
+<p>By default, the parser object is assigned to <code>module.exports</code>, which makes the
+output a Node.js module. You can assign it to another variable by passing a
+variable name using the <code>-e</code>/<code>--export-var</code> option. This may be helpful if you
+want to use the parser in browser environment.</p>
+
+<p>You can tweak the generated parser with several options:</p>
+
+<ul>
+<li>
+<code>--cache</code> — makes the parser cache results, avoiding exponential parsing
+time in pathological cases but making the parser slower</li>
+<li>
+<code>--allowed-start-rules</code> — comma-separated list of rules the parser will be
+allowed to start parsing from (default: the first rule in the grammar)</li>
+<li>
+<code>--plugin</code> — makes PEG.js use a specified plugin (can be specified multiple
+times)</li>
+<li>
+<code>--extra-options</code> — additional options (in JSON format) to pass to
+<code>PEG.buildParser</code>
+</li>
+<li>
+<code>--extra-options-file</code> — file with additional options (in JSON format) to
+pass to <code>PEG.buildParser</code>
+</li>
+</ul><h3>
+<a name="javascript-api" class="anchor" href="#javascript-api"><span class="octicon octicon-link"></span></a>JavaScript API</h3>
+
+<p>In Node.js, require the PEG.js parser generator module:</p>
+
+<pre><code>var PEG = require("pegjs");
+</code></pre>
+
+<p>In browser, include the PEG.js library in your web page or application using the
+<code>&lt;script&gt;</code> tag. The API will be available in the <code>PEG</code> global object.</p>
+
+<p>To generate a parser, call the <code>PEG.buildParser</code> method and pass your grammar as
+a parameter:</p>
+
+<pre><code>var parser = PEG.buildParser("start = ('a' / 'b')+");
+</code></pre>
+
+<p>The method will return generated parser object or its source code as a string
+(depending on the value of the <code>output</code> option — see below). It will throw an
+exception if the grammar is invalid. The exception will contain <code>message</code>
+property with more details about the error.</p>
+
+<p>You can tweak the generated parser by passing a second parameter with an options
+object to <code>PEG.buildParser</code>. The following options are supported:</p>
+
+<ul>
+<li>
+<code>cache</code> — if <code>true</code>, makes the parser cache results, avoiding exponential
+parsing time in pathological cases but making the parser slower (default:
+<code>false</code>)</li>
+<li>
+<code>allowedStartRules</code> — rules the parser will be allowed to start parsing from
+(default: the first rule in the grammar)</li>
+<li>
+<code>output</code> — if set to <code>"parser"</code>, the method will return generated parser
+object; if set to <code>"source"</code>, it will return parser source code as a string
+(default: <code>"parser"</code>)</li>
+<li>
+<code>optimize</code>— selects between optimizing the generated parser for parsing
+speed (<code>"speed"</code>) or code size (<code>"size"</code>) (default: <code>"speed"</code>)</li>
+<li>
+<code>plugins</code> — plugins to use</li>
+</ul><h2>
+<a name="using-the-parser" class="anchor" href="#using-the-parser"><span class="octicon octicon-link"></span></a>Using the Parser</h2>
+
+<p>Using the generated parser is simple — just call its <code>parse</code> method and pass an
+input string as a parameter. The method will return a parse result (the exact
+value depends on the grammar used to build the parser) or throw an exception if
+the input is invalid. The exception will contain <code>offset</code>, <code>line</code>, <code>column</code>,
+<code>expected</code>, <code>found</code> and <code>message</code> properties with more details about the error.</p>
+
+<pre><code>parser.parse("abba"); // returns ["a", "b", "b", "a"]
+
+parser.parse("abcd"); // throws an exception
+</code></pre>
+
+<p>You can tweak parser behavior by passing a second parameter with an options
+object to the <code>parse</code> method. Only one option is currently supported:</p>
+
+<ul>
+<li>
+<code>startRule</code> — name of the rule to start parsing from</li>
+</ul><p>Parsers can also support their own custom options.</p>
+
+<h2>
+<a name="grammar-syntax-and-semantics" class="anchor" href="#grammar-syntax-and-semantics"><span class="octicon octicon-link"></span></a>Grammar Syntax and Semantics</h2>
+
+<p>The grammar syntax is similar to JavaScript in that it is not line-oriented and
+ignores whitespace between tokens. You can also use JavaScript-style comments
+(<code>// ...</code> and <code>/* ... */</code>).</p>
+
+<p>Let's look at example grammar that recognizes simple arithmetic expressions like
+<code>2*(3+4)</code>. A parser generated from this grammar computes their values.</p>
+
+<pre><code>start
+  = additive
+
+additive
+  = left:multiplicative "+" right:additive { return left + right; }
+  / multiplicative
+
+multiplicative
+  = left:primary "*" right:multiplicative { return left * right; }
+  / primary
+
+primary
+  = integer
+  / "(" additive:additive ")" { return additive; }
+
+integer "integer"
+  = digits:[0-9]+ { return parseInt(digits.join(""), 10); }
+</code></pre>
+
+<p>On the top level, the grammar consists of <em>rules</em> (in our example, there are
+five of them). Each rule has a <em>name</em> (e.g. <code>integer</code>) that identifies the rule,
+and a <em>parsing expression</em> (e.g. <code>digits:[0-9]+ { return
+parseInt(digits.join(""), 10); }</code>) that defines a pattern to match against the
+input text and possibly contains some JavaScript code that determines what
+happens when the pattern matches successfully. A rule can also contain
+<em>human-readable name</em> that is used in error messages (in our example, only the
+<code>integer</code> rule has a human-readable name). The parsing starts at the first rule,
+which is also called the <em>start rule</em>.</p>
+
+<p>A rule name must be a JavaScript identifier. It is followed by an equality sign
+(“=”) and a parsing expression. If the rule has a human-readable name, it is
+written as a JavaScript string between the name and separating equality sign.
+Rules need to be separated only by whitespace (their beginning is easily
+recognizable), but a semicolon (“;”) after the parsing expression is allowed.</p>
+
+<p>Rules can be preceded by an <em>initializer</em> — a piece of JavaScript code in curly
+braces (“{” and “}”). This code is executed before the generated parser starts
+parsing. All variables and functions defined in the initializer are accessible
+in rule actions and semantic predicates. The code inside the initializer can
+access options passed to the parser using the <code>options</code> variable. Curly braces
+in the initializer code must be balanced. Let's look at the example grammar
+from above using a simple initializer.</p>
+
+<pre><code>{
+  function makeInteger(o) {
+    return parseInt(o.join(""), 10);
+  }
+}
+
+start
+  = additive
+
+additive
+  = left:multiplicative "+" right:additive { return left + right; }
+  / multiplicative
+
+multiplicative
+  = left:primary "*" right:multiplicative { return left * right; }
+  / primary
+
+primary
+  = integer
+  / "(" additive:additive ")" { return additive; }
+
+integer "integer"
+  = digits:[0-9]+ { return makeInteger(digits); }
+</code></pre>
+
+<p>The parsing expressions of the rules are used to match the input text to the
+grammar. There are various types of expressions — matching characters or
+character classes, indicating optional parts and repetition, etc. Expressions
+can also contain references to other rules. See detailed description below.</p>
+
+<p>If an expression successfully matches a part of the text when running the
+generated parser, it produces a <em>match result</em>, which is a JavaScript value. For
+example:</p>
+
+<ul>
+<li>An expression matching a literal string produces a JavaScript string
+containing matched part of the input.</li>
+<li>An expression matching repeated occurrence of some subexpression produces a
+JavaScript array with all the matches.</li>
+</ul><p>The match results propagate through the rules when the rule names are used in
+expressions, up to the start rule. The generated parser returns start rule's
+match result when parsing is successful.</p>
+
+<p>One special case of parser expression is a <em>parser action</em> — a piece of
+JavaScript code inside curly braces (“{” and “}”) that takes match results of
+some of the the preceding expressions and returns a JavaScript value. This value
+is considered match result of the preceding expression (in other words, the
+parser action is a match result transformer).</p>
+
+<p>In our arithmetics example, there are many parser actions. Consider the action
+in expression <code>digits:[0-9]+ { return parseInt(digits.join(""), 10); }</code>. It
+takes the match result of the expression [0-9]+, which is an array of strings
+containing digits, as its parameter. It joins the digits together to form a
+number and converts it to a JavaScript <code>number</code> object.</p>
+
+<h3>
+<a name="parsing-expression-types" class="anchor" href="#parsing-expression-types"><span class="octicon octicon-link"></span></a>Parsing Expression Types</h3>
+
+<p>There are several types of parsing expressions, some of them containing
+subexpressions and thus forming a recursive structure:</p>
+
+<h4>
+<a name="literalliteral" class="anchor" href="#literalliteral"><span class="octicon octicon-link"></span></a>"*literal*"<br>'*literal*'</h4>
+
+<p>Match exact literal string and return it. The string syntax is the same as in
+JavaScript. Appending <code>i</code> right after the literal makes the match
+case-insensitive.</p>
+
+<h4>
+<a name="" class="anchor" href="#"><span class="octicon octicon-link"></span></a>.</h4>
+
+<p>Match exactly one character and return it as a string.</p>
+
+<h4>
+<a name="characters" class="anchor" href="#characters"><span class="octicon octicon-link"></span></a>[*characters*]</h4>
+
+<p>Match one character from a set and return it as a string. The characters in the
+list can be escaped in exactly the same way as in JavaScript string. The list of
+characters can also contain ranges (e.g. <code>[a-z]</code> means “all lowercase letters”).
+Preceding the characters with <code>^</code> inverts the matched set (e.g. <code>[^a-z]</code> means
+“all character but lowercase letters”). Appending <code>i</code> right after the right
+bracket makes the match case-insensitive.</p>
+
+<h4>
+<a name="rule" class="anchor" href="#rule"><span class="octicon octicon-link"></span></a><em>rule</em>
+</h4>
+
+<p>Match a parsing expression of a rule recursively and return its match result.</p>
+
+<h4>
+<a name="-expression-" class="anchor" href="#-expression-"><span class="octicon octicon-link"></span></a>( <em>expression</em> )</h4>
+
+<p>Match a subexpression and return its match result.</p>
+
+<h4>
+<a name="expression-" class="anchor" href="#expression-"><span class="octicon octicon-link"></span></a><em>expression</em> *</h4>
+
+<p>Match zero or more repetitions of the expression and return their match results
+in an array. The matching is greedy, i.e. the parser tries to match the
+expression as many times as possible.</p>
+
+<h4>
+<a name="expression--1" class="anchor" href="#expression--1"><span class="octicon octicon-link"></span></a><em>expression</em> +</h4>
+
+<p>Match one or more repetitions of the expression and return their match results
+in an array. The matching is greedy, i.e. the parser tries to match the
+expression as many times as possible.</p>
+
+<h4>
+<a name="expression--2" class="anchor" href="#expression--2"><span class="octicon octicon-link"></span></a><em>expression</em> ?</h4>
+
+<p>Try to match the expression. If the match succeeds, return its match result,
+otherwise return an empty string.</p>
+
+<h4>
+<a name="-expression" class="anchor" href="#-expression"><span class="octicon octicon-link"></span></a>&amp; <em>expression</em>
+</h4>
+
+<p>Try to match the expression. If the match succeeds, just return an empty string
+and do not advance the parser position, otherwise consider the match failed.</p>
+
+<h4>
+<a name="-expression-1" class="anchor" href="#-expression-1"><span class="octicon octicon-link"></span></a>! <em>expression</em>
+</h4>
+
+<p>Try to match the expression. If the match does not succeed, just return an empty
+string and do not advance the parser position, otherwise consider the match
+failed.</p>
+
+<h4>
+<a name="--predicate-" class="anchor" href="#--predicate-"><span class="octicon octicon-link"></span></a>&amp; { <em>predicate</em> }</h4>
+
+<p>The predicate is a piece of JavaScript code that is executed as if it was inside
+a function. It gets the match results of labeled expressions in preceding
+expression as its arguments. It should return some JavaScript value using the
+<code>return</code> statement. If the returned value evaluates to <code>true</code> in boolean
+context, just return an empty string and do not advance the parser position;
+otherwise consider the match failed.</p>
+
+<p>The code inside the predicate can access all variables and functions defined in
+the initializer at the beginning of the grammar.</p>
+
+<p>The code inside the predicate can also access the current parse position using
+the <code>offset</code> function. It returns a zero-based character index into the input
+string. The code can also access the current line and column using the <code>line</code>
+and <code>column</code> functions. Both return one-based indexes.</p>
+
+<p>The code inside the predicate can also access options passed to the parser using
+the <code>options</code> variable.</p>
+
+<p>Note that curly braces in the predicate code must be balanced.</p>
+
+<h4>
+<a name="--predicate--1" class="anchor" href="#--predicate--1"><span class="octicon octicon-link"></span></a>! { <em>predicate</em> }</h4>
+
+<p>The predicate is a piece of JavaScript code that is executed as if it was inside
+a function. It gets the match results of labeled expressions in preceding
+expression as its arguments. It should return some JavaScript value using the
+<code>return</code> statement. If the returned value evaluates to <code>false</code> in boolean
+context, just return an empty string and do not advance the parser position;
+otherwise consider the match failed.</p>
+
+<p>The code inside the predicate can access all variables and functions defined in
+the initializer at the beginning of the grammar.</p>
+
+<p>The code inside the predicate can also access the current parse position using
+the <code>offset</code> function. It returns a zero-based character index into the input
+string. The code can also access the current line and column using the <code>line</code>
+and <code>column</code> functions. Both return one-based indexes.</p>
+
+<p>The code inside the predicate can also access options passed to the parser using
+the <code>options</code> variable.</p>
+
+<p>Note that curly braces in the predicate code must be balanced.</p>
+
+<h4>
+<a name="-expression-2" class="anchor" href="#-expression-2"><span class="octicon octicon-link"></span></a>$ <em>expression</em>
+</h4>
+
+<p>Try to match the expression. If the match succeeds, return the matched string
+instead of the match result.</p>
+
+<h4>
+<a name="label--expression" class="anchor" href="#label--expression"><span class="octicon octicon-link"></span></a><em>label</em> : <em>expression</em>
+</h4>
+
+<p>Match the expression and remember its match result under given label. The label
+must be a JavaScript identifier.</p>
+
+<p>Labeled expressions are useful together with actions, where saved match results
+can be accessed by action's JavaScript code.</p>
+
+<h4>
+<a name="expression1-expression2---expressionn" class="anchor" href="#expression1-expression2---expressionn"><span class="octicon octicon-link"></span></a><em>expression<sub>1</sub></em> <em>expression<sub>2</sub></em> ...  <em>expression<sub>n</sub></em>
+</h4>
+
+<p>Match a sequence of expressions and return their match results in an array.</p>
+
+<h4>
+<a name="expression--action-" class="anchor" href="#expression--action-"><span class="octicon octicon-link"></span></a><em>expression</em> { <em>action</em> }</h4>
+
+<p>Match the expression. If the match is successful, run the action, otherwise
+consider the match failed.</p>
+
+<p>The action is a piece of JavaScript code that is executed as if it was inside a
+function. It gets the match results of labeled expressions in preceding
+expression as its arguments. The action should return some JavaScript value
+using the <code>return</code> statement. This value is considered match result of the
+preceding expression. The action can return <code>null</code> to indicate a match failure.</p>
+
+<p>The code inside the action can access all variables and functions defined in the
+initializer at the beginning of the grammar. Curly braces in the action code
+must be balanced.</p>
+
+<p>The code inside the action can also access the string matched by the expression
+using the <code>text</code> function.</p>
+
+<p>The code inside the action can also access the parse position at the beginning
+of the action's expression using the <code>offset</code> function. It returns a zero-based
+character index into the input string. The code can also access the line and
+column at the beginning of the action's expression using the <code>line</code> and <code>column</code>
+functions. Both return one-based indexes.</p>
+
+<p>The code inside the action can also access options passed to the parser using
+the <code>options</code> variable.</p>
+
+<p>Note that curly braces in the action code must be balanced.</p>
+
+<h4>
+<a name="expression1--expression2----expressionn" class="anchor" href="#expression1--expression2----expressionn"><span class="octicon octicon-link"></span></a><em>expression<sub>1</sub></em> / <em>expression<sub>2</sub></em> / ... / <em>expression<sub>n</sub></em>
+</h4>
+
+<p>Try to match the first expression, if it does not succeed, try the second one,
+etc. Return the match result of the first successfully matched expression. If no
+expression matches, consider the match failed.</p>
+
+<h2>
+<a name="compatibility" class="anchor" href="#compatibility"><span class="octicon octicon-link"></span></a>Compatibility</h2>
+
+<p>Both the parser generator and generated parsers should run well in the following
+environments:</p>
+
+<ul>
+<li>Node.js 0.6.6+</li>
+<li>IE 8+</li>
+<li>Firefox</li>
+<li>Chrome</li>
+<li>Safari</li>
+<li>Opera</li>
+</ul><h2>
+<a name="development" class="anchor" href="#development"><span class="octicon octicon-link"></span></a>Development</h2>
+
+<ul>
+<li><a href="http://pegjs.majda.cz/">Project website</a></li>
+<li><a href="https://github.com/dmajda/pegjs/wiki">Wiki</a></li>
+<li><a href="https://github.com/dmajda/pegjs">Source code</a></li>
+<li><a href="https://trello.com/board/peg-js/50a8eba48cf95d4957006b01">Trello board</a></li>
+<li><a href="https://github.com/dmajda/pegjs/issues">Issue tracker</a></li>
+<li><a href="http://groups.google.com/group/pegjs">Google Group</a></li>
+<li><a href="http://twitter.com/peg_js">Twitter</a></li>
+</ul><p>PEG.js is developed by <a href="http://majda.cz/">David Majda</a>
+(<a href="http://twitter.com/dmajda">@dmajda</a>). You are welcome to contribute code.
+Unless your contribution is really trivial you should get in touch with me first
+— this can prevent wasted effort on both sides. You can send code both as a
+patch or a GitHub pull request.</p>
+
+<p>Note that PEG.js is still very much work in progress. There are no compatibility
+guarantees until version 1.0.</p></article>
+  </div>
+
+
+
+        </div>
+
+      </div><!-- /.repo-container -->
+      <div class="modal-backdrop"></div>
+    </div><!-- /.container -->
+  </div><!-- /.site -->
+
+
+    </div><!-- /.wrapper -->
+
+      <div class="container">
+  <div class="site-footer">
+    <ul class="site-footer-links right">
+      <li><a href="https://status.github.com/">Status</a></li>
+      <li><a href="http://developer.github.com">API</a></li>
+      <li><a href="http://training.github.com">Training</a></li>
+      <li><a href="http://shop.github.com">Shop</a></li>
+      <li><a href="/blog">Blog</a></li>
+      <li><a href="/about">About</a></li>
+
+    </ul>
+
+    <a href="/">
+      <span class="mega-octicon octicon-mark-github"></span>
+    </a>
+
+    <ul class="site-footer-links">
+      <li>&copy; 2013 <span title="0.07030s from github-fe109-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+        <li><a href="/site/terms">Terms</a></li>
+        <li><a href="/site/privacy">Privacy</a></li>
+        <li><a href="/security">Security</a></li>
+        <li><a href="/contact">Contact</a></li>
+    </ul>
+  </div><!-- /.site-footer -->
+</div><!-- /.container -->
+
+
+    <div class="fullscreen-overlay js-fullscreen-overlay" id="fullscreen_overlay">
+  <div class="fullscreen-container js-fullscreen-container">
+    <div class="textarea-wrap">
+      <textarea name="fullscreen-contents" id="fullscreen-contents" class="js-fullscreen-contents" placeholder="" data-suggester="fullscreen_suggester"></textarea>
+          <div class="suggester-container">
+              <div class="suggester fullscreen-suggester js-navigation-container" id="fullscreen_suggester"
+                 data-url="/dmajda/pegjs/suggestions/commit">
+              </div>
+          </div>
+    </div>
+  </div>
+  <div class="fullscreen-sidebar">
+    <a href="#" class="exit-fullscreen js-exit-fullscreen tooltipped leftwards" title="Exit Zen Mode">
+      <span class="mega-octicon octicon-screen-normal"></span>
+    </a>
+    <a href="#" class="theme-switcher js-theme-switcher tooltipped leftwards"
+      title="Switch themes">
+      <span class="octicon octicon-color-mode"></span>
+    </a>
+  </div>
+</div>
+
+
+
+    <div id="ajax-error-message" class="flash flash-error">
+      <span class="octicon octicon-alert"></span>
+      <a href="#" class="octicon octicon-remove-close close ajax-error-dismiss"></a>
+      Something went wrong with that request. Please try again.
+    </div>
+
+  </body>
+</html>
+

--- a/test/benchmarks/html/input/small.html
+++ b/test/benchmarks/html/input/small.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Title<!--comment--> of the page</title>
+</head>
+<body attr='attr_val'>
+	<div id = "id_val" single></div>
+	<br />
+	<![CDATA[
+	<br />
+	]]>
+	<br />
+	<br>
+</body>
+</html>

--- a/test/benchmarks/index.js
+++ b/test/benchmarks/index.js
@@ -1,0 +1,9 @@
+var modes = [
+	require('./html')
+	,
+	require('./at-html')
+]
+
+
+
+exports.modes = modes;

--- a/test/node_modules/benchmarker/benchmark.js
+++ b/test/node_modules/benchmarker/benchmark.js
@@ -1,0 +1,159 @@
+var prelude = require('prelude-ls');
+var now = require("performance-now");
+
+var oop = require('oop').oop;
+
+
+
+var Benchmark = oop.Class({
+	name: 'Benchmark',
+
+	description: 'A benchmark',
+
+	schema: {
+		properties: [
+			// Benchmark identification / description
+			{names: ['name', 'id', 'ID'], required: true},
+
+			{names: ['description', 'desc', 'doc', 'documentation', 'explanation'], required: false},
+
+			// Function to test
+			{names: ['fn', 'func', 'cb', 'handler', 'exec', 'process', 'run'], required: true},
+
+			['context', 'scope', 'environment', 'env', 'that', 'self'],
+
+			{
+				names: ['args', 'arguments', 'arg', 'argument', 'params', 'parameters', 'param', 'parameter'],
+				type: oop.types.Array, default: []
+			},
+
+			// Benchmark properties
+			{
+				names: ['max_time', 'max-time'],
+				desc: 'The maximum time to run the benchmark. Doesn\'t take into account the first run if drop_first is enabled. has precedence over the min_reps constraint. However, at least one run must be made for the benchmark, and this one can last any long.',
+				type: oop.types.Number, default: 1000
+			},
+			{
+				names: ['min_reps', 'min-reps', 'reps'],
+				desc: 'The prefered number of repetitions to execute.',
+				type: oop.types.Number, default: 5
+			},
+			{
+				names: ['drop_first', 'drop-first'],
+				desc: 'Before running the benchmark, run the function once, to avoid initialization side-effects',
+				type: oop.types.Boolean, default: true
+			}
+		]
+	},
+
+	statics: {
+		computeStats: function(result) {
+			var times = result.times;
+
+			// Executions
+			var executions = times.length;
+
+			// Total time, just to know
+			var total = prelude.sum(times);
+			// Mean time
+			var mean_ns = (total / executions) * 1000;
+			var mean_ms = total / executions;
+			var mean_s = total / executions / 1000;
+			// Ops/s
+			var ops_ns = 1 / mean_ns;
+			var ops_ms = 1 / mean_ms;
+			var ops_s = 1 / mean_s;
+			// Deviation
+
+			// variance
+
+			// -------
+
+			return {
+				executions: executions,
+				total: total,
+
+				mean_ns: mean_ns,
+				mean_ms: mean_ms,
+				mean_s: mean_s,
+
+				ops_ns: ops_ns,
+				ops_ms: ops_ms,
+				ops_s: ops_s
+			}
+		},
+	},
+
+	init: function() {
+		if (this.context == null) {this.context = this}
+	},
+
+	proto: {
+		run: function() {
+			var totalTime = 0;
+
+			if (this.drop_first) {
+				this.execOnce();
+			}
+
+			var times = [];
+			for (
+				var executions = 0, min_reps = this.min_reps;
+				executions < min_reps;
+				executions++
+			) {
+				var time = this.execOnce();
+
+				times.push(time);
+
+				totalTime += time;
+				if (totalTime >= this.max_time) {
+					break;
+				}
+			}
+
+			return {
+				times: times
+			};
+		},
+
+		runSimple: function() {
+			var totalTime = 0;
+
+			var times = [];
+			for (
+				var executions = 0, min_reps = this.min_reps;
+				executions < min_reps && totalTime < this.max_time;
+				executions++
+			) {
+				var time = this.execOnceSimple();
+				times.push(time);
+				totalTime += time;
+			}
+
+			return {
+				times: times
+			};
+		},
+
+		execOnce: function() {
+			var start = now();
+			this.fn.apply(this.context, this.args);
+			var end = now();
+			return end - start;
+		},
+
+		execOnceSimple: function() {
+			var start = now();
+			this.fn();
+			var end = now();
+			return end - start;
+		}
+
+	}
+})
+
+
+
+
+exports.Benchmark = Benchmark;

--- a/test/node_modules/benchmarker/benchmark_test.js
+++ b/test/node_modules/benchmarker/benchmark_test.js
@@ -1,0 +1,47 @@
+var Logger = require('tester').logger.Logger;
+
+var Benchmark = require('./benchmark').Benchmark;
+
+
+
+var $logger = new Logger();
+
+
+// -----------------------------------------------------------------------------
+
+$logger.sep('First test')
+$logger.on();
+
+var benchmark = Benchmark({
+	name: 'First benchmark test',
+	description: 'This is a simple test to know if my benchmark class works',
+
+	fn: function() {
+		return 5;
+	}
+});
+
+$logger.log(benchmark);
+
+var result = benchmark.run();
+$logger.log(result);
+$logger.log(Benchmark.computeStats(result));
+
+
+var result = benchmark.runSimple();
+$logger.log(result);
+$logger.log(Benchmark.computeStats(result));
+
+
+// -----------------------------------------------------------------------------
+
+$logger.sep('Long test')
+$logger.on();
+
+// ,
+// 	context: {
+
+// 	},
+// 	args: [
+
+// 	]

--- a/test/node_modules/benchmarker/helpers.js
+++ b/test/node_modules/benchmarker/helpers.js
@@ -1,0 +1,124 @@
+// --------------------------------------------------------------------- Helpers
+
+/**
+ * Populates the last given argument with properties of all previous arguments, in the given order.
+ */
+function mixin() {
+	var args = Array.prototype.slice.call(arguments);
+
+	var source = args.pop();
+
+	for (var i = 0, length = args.length; i < length; i++) {
+		var addon = args[i];
+
+		for (var key in addon) {
+			if ({}.hasOwnProperty.call(addon, key)) {
+				source[key] = addon[key];
+			}
+		}
+	}
+
+	return source;
+}
+
+function each(cb, array) {
+	for (var index = 0, length = array.length; index < length; index++) {
+		if (cb(array[index], index, array) === true) {
+			break;
+		}
+	}
+
+	return index;
+}
+
+function map(cb, array) {
+	var result = [];
+
+	for (var index = 0, length = array.length; index < length; index++) {
+		try {
+			result.push(cb(array[index], index, array));
+		} catch (exception) {
+			break;
+		}
+	}
+
+	return result;
+}
+
+
+// --------------------------------------------------------------------- Logging
+
+function pluralize(term, value, plural) {
+	if (plural == null) {plural = 's'}
+	return term + (value > 1 ? plural : '');
+}
+
+function truncateNumber(value, maxDecimals) {
+	if (maxDecimals == null) {maxDecimals = 3}
+	return value.toFixed(maxDecimals);
+}
+
+function completeLine(text, options) {
+	if (options == null) {options = {}};
+	if (options.character == null) {options.character = '-'};
+	if (options.width == null) {options.width = 80};
+	if (options.addSpace == null) {options.addSpace = true};
+
+	var output;
+
+	output = text;
+
+	if (output.length >= options.width) {
+		return output;
+	}
+
+	if (options.addSpace) {
+		if (output.length >= options.width + 1) {
+			return output
+		}
+
+		output += ' ';
+	}
+
+	for (
+		var i = 0, length = options.width - output.length;
+		i < length;
+		i++
+	) {
+		output += options.character;
+	}
+
+	return output;
+}
+
+/**
+ * Takes input as seconds.
+ */
+function humanizeDuration(value) {
+	var units = ['s', 'ms', 'ns'];
+	for (i = 0, length = units.length - 1; i < length; i++) {
+		if (value >= 1) {
+			break;
+		}
+		value *= 1000;
+	}
+	return truncateNumber(value) + units[i];
+
+	// if (value >= 1) return truncateNumber(value) + "s";
+	// value *= 1000;
+	// if (value >= 1) return truncateNumber(value) + "ms";
+	// value *= 1000;
+	// return truncateNumber(value) + "ns";
+}
+
+
+
+exports.mixin = mixin;
+exports.each = each;
+exports.map = map;
+
+exports.pluralize = pluralize;
+exports.truncateNumber = truncateNumber;
+
+exports.humanizeDuration = humanizeDuration;
+exports.completeLine = completeLine;

--- a/test/node_modules/benchmarker/index.js
+++ b/test/node_modules/benchmarker/index.js
@@ -1,0 +1,147 @@
+var prelude = require('prelude-ls');
+var benchmark = require('benchmark');
+var colour = require('colour');
+
+var helpers = require('./helpers');
+
+
+
+// --------------------------------------------------------------------- Logging
+
+// Configures logging system
+// Defines specific data logging functions
+
+colour.setTheme({
+	start: ['magenta'],
+	cycle: ['green', 'bold'],
+	abort: ['red', 'bold'],
+	error: ['red', 'bold'],
+	reset: ['magenta'],
+	complete: ['green', 'bold'],
+
+	name: ['cyan', 'bold', 'italic']
+});
+
+function logBenchmark(benchmark) {
+	console.log(benchmark.name.name);
+
+	console.log("Mean time: " + helpers.humanizeDuration(benchmark.stats.mean) + " (" + helpers.truncateNumber(benchmark.hz) + " ops/s).");
+
+	console.log("(deviation: " + benchmark.stats.deviation + " - variance: " + benchmark.stats.variance + ")");
+	console.log();
+}
+
+
+
+// ----------------------------------------------------------- Benchmark helpers
+
+var handlers = {
+	onStart: function() {
+		console.log(helpers.completeLine("Starting: " + this.name).start);
+	},
+	// onCycle: function() {
+	// 	console.log("Cycle finished".cycle);
+	// },
+	onAbort: function() {
+		console.log((this.name + " aborted").abort);
+	},
+	onError: function(error) {
+		console.log("An error occurred!".abort);
+		console.error(error.message);
+		// process.exit(1);
+	},
+	onReset: function() {
+		console.log((this.name + " reset.").reset);
+	},
+	onComplete: function() {
+		console.log((this.name + " completed successfully!").complete);
+	}
+};
+
+var benchmarkHandlers = {
+	onComplete: function() {
+		console.log("Completed successfully: ".complete);
+		logBenchmark(this);
+	},
+
+	onStart: function() {
+		console.log(("Starting: " + this.name).start);
+	}
+};
+
+
+
+// ---------------------------------------------------------------------- Export
+
+exports.benchmarker_1 = function(name, parsers, inputs) {
+	var suite = benchmark.Benchmark.Suite(helpers.mixin(handlers, {name: name}));
+
+	prelude.each(function(input) {
+		prelude.each(function(parser) {
+			suite.add(helpers.mixin(handlers, benchmarkHandlers, {
+				name: 'Parser: ' + parser.name + ' / input: ' + input.name,
+				fn: function() {
+					parser.parser.parse(input.source);
+				}
+			}));
+		}, parsers);
+	}, inputs);
+
+	suite.run();
+
+	// return suite;
+
+	return {
+		name: suite.name,
+		result: prelude.map(function(benchmark) {
+			return {
+				result: {
+					times: benchmark.stats.sample
+				},
+				stats: {
+					executions: benchmark.stats.sample.length,
+					total: benchmark.times.elapsed * 1000,
+
+					mean_ns: benchmark.stats.mean * 1000,
+					mean_ms: benchmark.stats.mean,
+					mean_s: benchmark.stats.mean / 1000,
+
+					ops_ns: benchmark.hz / 1000,
+					ops_ms: benchmark.hz,
+					ops_s: benchmark.hz * 1000
+				},
+				benchmark: benchmark.name,
+				_benchmark: {
+					count: benchmark.count, // total count
+					cycles: benchmark.cycles, // number of cycles, ?
+					hz: benchmark.hz // ops/s
+				}
+			}
+		}, suite)
+	};
+}
+
+
+
+var Suite = require('./suite').Suite;
+
+exports.benchmarker_2 = function(name, parsers, inputs) {
+	var benchmarks = [];
+	prelude.each(function(input) {
+		prelude.each(function(parser) {
+			benchmarks.push({
+				name: 'Parser: ' + parser.name + ' / input: ' + input.name,
+				fn: function() {
+					parser.parser.parse(input.source);
+				}
+			});
+		}, parsers);
+	}, inputs);
+
+	var suite = Suite({
+		name: name,
+		benchmarks: benchmarks
+	});
+
+	return suite.run(true);
+}

--- a/test/node_modules/benchmarker/suite.js
+++ b/test/node_modules/benchmarker/suite.js
@@ -1,0 +1,128 @@
+var prelude = require('prelude-ls');
+var colour = require('colour');
+
+var oop = require('oop').oop;
+var helpers = require('./helpers');
+
+var Benchmark = require('./benchmark').Benchmark;
+
+
+
+// -----------------------------------------------------------------------------
+
+colour.setTheme({
+	start: ['magenta', 'bold'],
+	end: ['green', 'bold'],
+
+	name: ['cyan', 'bold'],
+	delimiter: ['cyan', 'bold'],
+
+	error: ['red', 'bold']
+});
+
+
+
+// -----------------------------------------------------------------------------
+
+var Suite = oop.Class({
+	name: 'Suite',
+
+	description: 'A suite of benchmarks',
+
+	schema: {
+		properties: [
+			// Suite identification / description
+			{names: ['name', 'id', 'ID'], required: true},
+			{names: ['description', 'desc', 'doc', 'documentation', 'explanation'], required: false},
+
+			// Benchmarks
+			{names: ['benchmarks', 'benchmark', 'bench', 'benchs', 'tests', 'test'], type: oop.types.Array, default: []}
+		]
+	},
+
+	init: function() {
+		this.benchmarks = prelude.map(function(input) {
+			return Benchmark.factory(input);
+		}, this.benchmarks);
+	},
+
+	statics: {
+		logBenchmark: function(result) {
+			var output = '';
+
+			var benchmark = result.benchmark;
+
+			var stats = result.stats;
+
+			output += "(";
+			output += "executed " + stats.executions + " " + helpers.pluralize("time", stats.executions);
+			output += " in " + helpers.humanizeDuration(stats.total / 1000);
+			output += ")";
+			output += '\n';
+
+			output += "Mean time: " + helpers.humanizeDuration(stats.mean_s) + " (" + helpers.truncateNumber(stats.ops_s) + " ops/s).";
+
+			output += '\n';
+
+			console.log(output);
+		}
+	},
+
+	proto: {
+		run: function(log) {
+			log = !!log;
+
+			if (log) {
+				console.log(helpers.completeLine(this.name, {width: 80}).start);
+			}
+
+			var result;
+			try {
+				result = helpers.map(function(benchmark, index, benchmarks) {
+					if (log) {
+						console.log(benchmark.name.name);
+					}
+
+					var benchmarkResult;
+					try {
+						benchmarkResult = benchmark.run();
+					}
+					catch (exception) {
+						console.error("An error occured: ".error);
+						console.error(exception);
+						console.error(exception.stack);
+						return null;
+					}
+
+					var result = {
+						result: benchmarkResult,
+						stats: Benchmark.computeStats(benchmarkResult),
+						benchmark: benchmark
+					};
+
+					if (log) {
+						Suite.logBenchmark(result);
+						if (index < benchmarks.length - 1) {
+							console.log(helpers.completeLine('', {addSpace: false, width: 40}).delimiter);
+						}
+					}
+
+					return result;
+				}, this.benchmarks);
+			} catch (exception) {}
+
+			if (log) {
+				console.log(helpers.completeLine('', {addSpace: false, width: 80}).end);
+			}
+
+			return {
+				result: result,
+				suite: this
+			};
+		}
+	}
+});
+
+
+
+exports.Suite = Suite;

--- a/test/node_modules/benchmarker/suite_test.js
+++ b/test/node_modules/benchmarker/suite_test.js
@@ -1,0 +1,73 @@
+var Logger = require('tester').logger.Logger;
+
+var Suite = require('./suite').Suite;
+
+
+
+var $logger = new Logger();
+
+
+// -----------------------------------------------------------------------------
+
+$logger.sep('First test');
+// $logger.on();
+
+var suite = Suite({
+	name: 'First suite test',
+	description: 'This is a simple test to know if my suite class works',
+
+	benchmarks: [
+		{
+			name: 'First',
+			fn: function() {
+				return 5;
+			}
+		}, {
+			name: 'Second',
+			fn: function() {
+				return 5;
+			}
+		}
+	]
+});
+
+$logger.log(suite);
+
+$logger.del();
+var result = suite.run(true);
+$logger.del();
+$logger.log(result);
+
+// -----------------------------------------------------------------------------
+
+$logger.sep('Exception');
+$logger.on();
+$logger.on();
+
+var suite = Suite({
+	name: 'Exception',
+
+	benchmarks: [
+		{
+			name: 'First',
+			fn: function() {
+				return 5;
+			}
+		}, {
+			name: 'Second',
+			fn: function() {
+				throw 'Second function failed!';
+			}
+		}, {
+			name: 'Third',
+			fn: function() {
+				return 5;
+			}
+		}
+	]
+});
+
+$logger.del();
+var result = suite.run(true);
+$logger.del();
+$logger.log(result);


### PR DESCRIPTION
A new utility has been created in tests, in order to run benchmarks.

This utility relies on a benchmarking library, and mainly takes care of getting the inputs and displaying the results.

For now it can use two benchmarking libraries:
- the renowned benchmark.js library
- a custom one developed internally, to have more control on how to benchmark and get significant results

It uses the second by default.

Here are the changes that have been done along with that:
- added npm script definition tun run the benchmarks
- added development dependencies for testing, mainly benchmarking
- added inputs to benchmark the parsers HTML and AT-HTML
