### PR TITLE
Optimized a lot the parsers.

### DIFF
--- a/app/node_modules/modes/at-html/parser/grammar.pegjs
+++ b/app/node_modules/modes/at-html/parser/grammar.pegjs
@@ -3,7 +3,7 @@
 {
 	var lib = require('pegjs-parser/initializer');
 
-	var Node = new lib.NodeInstancier('at-html');
+	var Node = new lib.NodeInstancier('at-html', true);
 
 	var validator = require('../validator');
 
@@ -28,7 +28,7 @@
 // Grammar ---------------------------------------------------------------------
 
 start = content:ATHTMLnode* {
-	var node =  Node('root', line(), column(), offset(), text());
+	var node =  Node('root', null, null, offset(), text());
 	node.addList('content', lib.flatten(content));
 	validator.reportErrors();
 	validator.restartTracking();
@@ -69,7 +69,7 @@ blockStatementOpeningWithoutClosing = opening:blockStatementOpening {
 	var id = opening.childrenIndex.id ? opening.childrenIndex.id.source : "";
 	var type = validator.getType(id);
 
-	var node = Node('block-' + type, line(), column(), offset(), text());
+	var node = Node('block-' + type, null, null, offset(), text());
 	opening.addError("Missing closing statement for " + type + " " + id);
 	node.add('openTag', opening);
 	return node;
@@ -79,20 +79,20 @@ blockStatementClosingWithoutOpening = closing:blockStatementClosing {
 	var id = closing.childrenIndex.id ? closing.childrenIndex.id.source : "";
 	var type = validator.getType(id);
 
-	var node = Node('block-' + type, line(), column(), offset(), text());
+	var node = Node('block-' + type, null, null, offset(), text());
 	closing.addError("Missing opening statement for " + type + " " + id);
 	node.add('closeTag', closing);
 	return node;
 }
 
 blockStatementClosingClosingWithoutOpening = "{/" .* {
-	var node = Node('statement', line(), column(), offset(), text());
+	var node = Node('statement', null, null, offset(), text());
 	node.addError('This statement should be closed');
 	return node;
 }
 
 statementOpeningWithoutClosing = "{" !"/" .* {
-	var node = Node('statement', line(), column(), offset(), text());
+	var node = Node('statement', null, null, offset(), text());
 	node.addError('This statement should be closed');
 	return node;
 }
@@ -109,9 +109,9 @@ blockStatementClosingWithoutOpeningInHtmlBlock = opening:blockStatementClosingOp
 	var type = validator.getType(idSource);
 
 
-	var node = Node('block-' + type, line(), column(), offset(), text());
+	var node = Node('block-' + type, null, null, offset(), text());
 
-	var innerNode = Node('closing', line(), column(), offset(), text());
+	var innerNode = Node('closing', null, null, offset(), text());
 
 	innerNode.addError("Missing opening statement for " + type + " " + idSource);
 
@@ -134,7 +134,7 @@ blockStatementClosingWithoutOpeningInHtmlBlock = opening:blockStatementClosingOp
 // ---------------- CDATA
 
 cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing {
-	var node = Node('block-statement', line(), column(), offset(), text());
+	var node = Node('block-statement', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -161,7 +161,7 @@ cdataOpening = "{CDATA" [^}/]* "}" {
 }
 
 cdataContent = (!cdataClosing .)+ {
-	return Node('block-statement-content', line(), column(), offset(), text());
+	return Node('block-statement-content', null, null, offset(), text());
 }
 
 cdataClosing = "{/CDATA}" {
@@ -184,7 +184,7 @@ blockStatement = opening:blockStatementOpening content:blockStatementContent? cl
 	var closingId = closing.childrenIndex.id ? closing.childrenIndex.id.source : "";
 	var type = validator.getType(openingId);
 
-	var node = Node('block-' + type, line(), column(), offset(), text());
+	var node = Node('block-' + type, null, null, offset(), text());
 
 	node.add('openTag', opening);
 	if (content) {
@@ -204,7 +204,7 @@ blockStatementContent = content:(ATnodeInStatement / HTMLnode)* {
 	if (content && content.length == 0) {
 		return null;
 	}
-	var node =  Node('block-statement-content', line(), column(), offset(), text());
+	var node =  Node('block-statement-content', null, null, offset(), text());
 	if (content) {
 		node.addList('content', lib.flatten(content));
 	}
@@ -212,7 +212,7 @@ blockStatementContent = content:(ATnodeInStatement / HTMLnode)* {
 }
 
 blockStatementOpening = opening:blockStatementOpeningOpening !"/" id:id? param:blockStatementParam? closing:blockStatementOpeningClosing {
-	var node = Node('opening', line(), column(), offset(), text());
+	var node = Node('opening', null, null, offset(), text());
 	node.add('opening', opening);
 	if (id !== null) {
 		node.add('id', id);
@@ -229,20 +229,20 @@ blockStatementOpening = opening:blockStatementOpeningOpening !"/" id:id? param:b
 }
 
 blockStatementOpeningOpening = "{" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 blockStatementParam = genericParam
 
 
 blockStatementOpeningClosing = "}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 
 
 blockStatementClosing = opening:blockStatementClosingOpening id:id? extra:extraParamsInBlockStatementClosing? closing:blockStatementClosingClosing {
-	var node = Node('closing', line(), column(), offset(), text());
+	var node = Node('closing', null, null, offset(), text());
 	node.add('opening', opening);
 	if (id !== null) {
 		node.add('id', id);
@@ -258,17 +258,17 @@ blockStatementClosing = opening:blockStatementClosingOpening id:id? extra:extraP
 }
 
 extraParamsInBlockStatementClosing = $(!blockStatementClosingClosing .)+ {
-	var node = Node('extra-parameters-in-closing-tag', line(), column(), offset(), text());
+	var node = Node('extra-parameters-in-closing-tag', null, null, offset(), text());
 	node.addError('Closing statement tag does not accept any parameter. Remove everything between the statement name and the closing bracket');
 	return node;
 }
 
 blockStatementClosingOpening = "{/" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 blockStatementClosingClosing = "}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 
@@ -278,7 +278,7 @@ inlineStatement = opening:inlineOpening id:id? param:inlineStatementParam? closi
 	var tagId = id ? id.source : "";
 	var type = validator.getType(tagId);
 
-	var node = Node('inline-' + type, line(), column(), offset(), text());
+	var node = Node('inline-' + type, null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -297,11 +297,11 @@ inlineStatement = opening:inlineOpening id:id? param:inlineStatementParam? closi
 }
 
 inlineOpening = "{" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 inlineClosing = "/}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 inlineStatementParam = value:$(!"/}" .)*&{
@@ -333,7 +333,7 @@ inlineStatementParam = value:$(!"/}" .)*&{
 // --------------------------------------------------------------- AT Expression
 
 expression = opening:expressionOpening param:expressionParam? closing:expressionClosing? {
-	var node = Node('expression', line(), column(), offset(), text());
+	var node = Node('expression', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -353,11 +353,11 @@ expression = opening:expressionOpening param:expressionParam? closing:expression
 }
 
 expressionOpening = "${" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 expressionClosing = "}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 expressionParam = genericParam
@@ -388,7 +388,7 @@ genericSingleParam =
 bracedParam = $(nonbraced / braced)
 
 braced = value:$("{" content:bracedParam* "}") {
-	var node = Node('param', line(), column(), offset(), text());
+	var node = Node('param', null, null, offset(), text());
 	node.set('value', value);
 	return node;
 }
@@ -396,7 +396,7 @@ braced = value:$("{" content:bracedParam* "}") {
 nonbraced =  $(escapedBrackets / [^{}])+
 
 nonbracedNospace = value:$(escapedBrackets / [^{} \r\n\t])+ {
-	var node = Node('param', line(), column(), offset(), text());
+	var node = Node('param', null, null, offset(), text());
 	node.set('value', value);
 	return node;
 }
@@ -417,7 +417,7 @@ comment =
 	/ singleLineComment
 
 multiLineComment = opening:multiLineCommentOpening content:multiLineCommentContent? closing:multiLineCommentClosing? {
-	var node = Node('multi-line-comment', line(), column(), offset(), text());
+	var node = Node('multi-line-comment', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (content !== null) {
@@ -433,19 +433,19 @@ multiLineComment = opening:multiLineCommentOpening content:multiLineCommentConte
 }
 
 multiLineCommentOpening = "/*" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 multiLineCommentClosing = "*/" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 multiLineCommentContent = (!multiLineCommentClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 singleLineComment =  opening:singleLineCommentOpening content:singleLineCommentContent? {
-	var node = Node('single-line-comment', line(), column(), offset(), text());
+	var node = Node('single-line-comment', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (content !== null) {
@@ -456,16 +456,16 @@ singleLineComment =  opening:singleLineCommentOpening content:singleLineCommentC
 }
 
 singleLineCommentOpening = "//" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 
 }
 
 singleLineCommentClosing = node:eol {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 singleLineCommentContent = (!singleLineCommentClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 
@@ -476,7 +476,7 @@ id =
 	/ widgetId
 
 widgetId = "@" library:libraryId? separator:":"? widgetName:widgetName? {
-	var node = Node('at-widget-id', line(), column(), offset(), text());
+	var node = Node('at-widget-id', null, null, offset(), text());
 
 	if (library !== null) {
 		node.add('library', library);
@@ -494,15 +494,15 @@ widgetId = "@" library:libraryId? separator:":"? widgetName:widgetName? {
 }
 
 widgetName = simpleId {
-	return Node('at-widget-name', line(), column(), offset(), text());
+	return Node('at-widget-name', null, null, offset(), text());
 }
 
 libraryId = simpleId {
-	return Node('at-widget-library', line(), column(), offset(), text());
+	return Node('at-widget-library', null, null, offset(), text());
 }
 
 statementId = simpleId {
-	return Node('at-id', line(), column(), offset(), text());
+	return Node('at-id', null, null, offset(), text());
 }
 
 simpleId = idhead idrest*
@@ -554,7 +554,7 @@ htmlElement =
 
 blockHtmlElementOpeningWithoutClosing = opening:blockHtmlTagOpening {
 	var id = opening.childrenIndex.id ? opening.childrenIndex.id.source : "";
-	var node = Node('block-html-element', line(), column(), offset(), text());
+	var node = Node('block-html-element', null, null, offset(), text());
 	opening.addWarning("Closing tag for element " + id + " might be missing");
 	node.add('openTag', opening);
 	return node;
@@ -562,20 +562,20 @@ blockHtmlElementOpeningWithoutClosing = opening:blockHtmlTagOpening {
 
 blockHtmlElementClosingWithoutOpening = closing:blockHtmlTagClosing {
 	var id = closing.childrenIndex.id ? closing.childrenIndex.id.source : "";
-	var node = Node('block-html-element', line(), column(), offset(), text());
+	var node = Node('block-html-element', null, null, offset(), text());
 	closing.addWarning("Opening tag for element " + id + " might be missing");
 	node.add('closeTag', closing);
 	return node;
 }
 
 blockHtmlElementClosingClosingWithoutOpening = "</" .* {
-	var node = Node('html-element', line(), column(), offset(), text());
+	var node = Node('html-element', null, null, offset(), text());
 	node.addError('This tag should be closed');
 	return node;
 }
 
 htmlElementOpeningWithoutClosing = "<" !"/" .* {
-	var node = Node('html-element', line(), column(), offset(), text());
+	var node = Node('html-element', null, null, offset(), text());
 	node.addError('This tag should be closed');
 	return node;
 }
@@ -583,7 +583,7 @@ htmlElementOpeningWithoutClosing = "<" !"/" .* {
 // ---------------- CDATA
 
 htmlCdata = opening:htmlCdataOpening content:htmlCdataContent? closing:htmlCdataClosing {
-	var node = Node('html-cdata', line(), column(), offset(), text());
+	var node = Node('html-cdata', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -597,15 +597,15 @@ htmlCdata = opening:htmlCdataOpening content:htmlCdataContent? closing:htmlCdata
 }
 
 htmlCdataOpening = "<![CDATA[" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 htmlCdataClosing = "]]>" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 htmlCdataContent = (!htmlCdataClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 
@@ -616,7 +616,7 @@ blockHtmlElement = opening:blockHtmlTagOpening content:blockHtmlTagContent? clos
 	var openingId = opening.childrenIndex.id ? opening.childrenIndex.id.source : "";
 	var closingId = closing.childrenIndex.id ? closing.childrenIndex.id.source : "";
 
-	var node = Node('block-html-element', line(), column(), offset(), text());
+	var node = Node('block-html-element', null, null, offset(), text());
 
 	node.add('openTag', opening);
 	if (content) {
@@ -636,7 +636,7 @@ blockHtmlTagContent = content:(ATnodeInStatement / blockStatementClosingWithoutO
 	if (content && content.length == 0) {
 		return null;
 	}
-	var node =  Node('block-html-element-content', line(), column(), offset(), text());
+	var node =  Node('block-html-element-content', null, null, offset(), text());
 	if (content) {
 		node.addList('content', lib.flatten(content));
 	}
@@ -644,7 +644,7 @@ blockHtmlTagContent = content:(ATnodeInStatement / blockStatementClosingWithoutO
 }
 
 blockHtmlTagOpening = opening:blockHtmlTagOpeningOpening !"/" id:htmlId? param:blockHtmlTagParam? closing:blockHtmlTagOpeningClosing {
-	var node = Node('opening', line(), column(), offset(), text());
+	var node = Node('opening', null, null, offset(), text());
 	node.add('opening', opening);
 	if (id !== null) {
 		node.add('id', id);
@@ -661,7 +661,7 @@ blockHtmlTagOpening = opening:blockHtmlTagOpeningOpening !"/" id:htmlId? param:b
 }
 
 blockHtmlTagOpeningOpening = "<" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 blockHtmlTagParam = values:(wsSequence / comment / textWithoutTagEnd / expression / statement)* {
@@ -670,12 +670,12 @@ blockHtmlTagParam = values:(wsSequence / comment / textWithoutTagEnd / expressio
 
 
 blockHtmlTagOpeningClosing = ">" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 
 blockHtmlTagClosing =opening:blockHtmlTagClosingOpening  ws0:wsSequence? id:htmlId? ws1:__? extra:extraParamsInBlockHtmlTagClosing? closing:blockHtmlTagClosingClosing {
-	var node = Node('closing', line(), column(), offset(), text());
+	var node = Node('closing', null, null, offset(), text());
 	node.add('opening', opening);
 
 	if (ws0 !== null) {
@@ -700,23 +700,23 @@ blockHtmlTagClosing =opening:blockHtmlTagClosingOpening  ws0:wsSequence? id:html
 }
 
 extraParamsInBlockHtmlTagClosing = $(!blockHtmlTagClosingClosing .)+ {
-	var node = Node('extra-parameters-in-closing-tag', line(), column(), offset(), text());
+	var node = Node('extra-parameters-in-closing-tag', null, null, offset(), text());
 	node.addError('Closing element tag does not accept any parameter.');
 	return node;
 }
 
 blockHtmlTagClosingOpening = "</" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 blockHtmlTagClosingClosing = ">" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 
 // specific text for opening tag parameter
 textWithoutTagEnd = $((escapedBrackets / !keywordStartAndTagEnd) .)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 keywordStartAndTagEnd = "${" / "{" / "/*" / "//" / "<" / "</" / ">"
@@ -727,7 +727,7 @@ keywordStartAndTagEnd = "${" / "{" / "/*" / "//" / "<" / "</" / ">"
 inlineHtmlElement = opening:inlineHtmlTagOpening id:htmlId? param:inlineHtmlTagParam? closing:inlineHtmlTagClosing {
 	var tagId = id !== null ? id.source : "";
 
-	var node = Node('inline-html-element', line(), column(), offset(), text());
+	var node = Node('inline-html-element', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (id !== null) {
@@ -744,11 +744,11 @@ inlineHtmlElement = opening:inlineHtmlTagOpening id:htmlId? param:inlineHtmlTagP
 }
 
 inlineHtmlTagOpening = "<" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 inlineHtmlTagClosing = "/>" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 inlineHtmlTagParam = value:$(!"/>" .)*&{
@@ -783,7 +783,7 @@ htmlTagParamContent = values:ATnodeInStatement* {
 // -------------------------------------------------------------------- Comments
 
 htmlComment = opening:htmlCommentOpening content:htmlCommentContent? closing:htmlCommentClosing {
-	var node = Node('html-comment', line(), column(), offset(), text());
+	var node = Node('html-comment', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (content !== null) {
@@ -795,15 +795,15 @@ htmlComment = opening:htmlCommentOpening content:htmlCommentContent? closing:htm
 }
 
 htmlCommentOpening = "<!--" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 htmlCommentClosing = "-->" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 htmlCommentContent = (!htmlCommentClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 
@@ -811,7 +811,7 @@ htmlCommentContent = (!htmlCommentClosing .)+ {
 
 
 htmlId = htmlIdhead htmlIdrest* {
-	return Node('html-id', line(), column(), offset(), text());
+	return Node('html-id', null, null, offset(), text());
 }
 
 htmlIdhead = htmlIdchars
@@ -835,7 +835,7 @@ htmlIdspecial = [$_]
 
 
 text = $((escapedBrackets / !keywordStart) .)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 keywordStart = "${" / "{" / "/*" / "//" / "<" / "</"
@@ -848,19 +848,19 @@ ws = [ \r\n\t]
 wsSequence = nodes:(spaces / tabs / eols)+
 
 spaces = content:" "+ {
-	var node = Node('spaces', line(), column(), offset(), text());
+	var node = Node('spaces', null, null, offset(), text());
 	node.set('size', content.length);
 	return node;
 }
 
 tabs = content:"\t"+ {
-	var node = Node('tabs', line(), column(), offset(), text());
+	var node = Node('tabs', null, null, offset(), text());
 	node.set('size', content.length);
 	return node;
 }
 
 eols = content:eol+ {
-	var node = Node('eols', line(), column(), offset(), text());
+	var node = Node('eols', null, null, offset(), text());
 	node.set('size', content.length);
 	return node;
 }
@@ -874,7 +874,7 @@ string =
 	/ singleQuoteString
 
 doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent? closing:doubleQuoteStringQuote {
-	var node = Node('string', line(), column(), offset(), text());
+	var node = Node('string', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (raw !== null) {
@@ -886,16 +886,16 @@ doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent?
 }
 
 doubleQuoteStringQuote = '"' {
-	return Node('quotes.double', line(), column(), offset(), text());
+	return Node('quotes.double', null, null, offset(), text());
 }
 
 doubleQuoteStringContent = $(!'"' .)+ {
-	return Node('doubleQuoteString.content', line(), column(), offset(), text());
+	return Node('doubleQuoteString.content', null, null, offset(), text());
 }
 
 
 singleQuoteString = opening:singleQuoteStringQuote raw:singleQuoteStringContent? closing:singleQuoteStringQuote {
-	var node = Node('string', line(), column(), offset(), text());
+	var node = Node('string', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (raw !== null) {
@@ -907,11 +907,11 @@ singleQuoteString = opening:singleQuoteStringQuote raw:singleQuoteStringContent?
 }
 
 singleQuoteStringQuote = "'" {
-	return Node('quotes.single', line(), column(), offset(), text());
+	return Node('quotes.single', null, null, offset(), text());
 }
 
 singleQuoteStringContent = $(!"'" .)+ {
-	return Node('singleQuoteString.content', line(), column(), offset(), text());
+	return Node('singleQuoteString.content', null, null, offset(), text());
 }
 
 

--- a/app/node_modules/modes/at-html/parser/options.json
+++ b/app/node_modules/modes/at-html/parser/options.json
@@ -39,7 +39,7 @@
 		"htmlCdata",
 		"htmlComment"
 	],
-	"cache": false,
+	"cache": true,
 	"optimize": "speed",
 	"plugins": []
 }

--- a/app/node_modules/modes/at/parser/grammar.pegjs
+++ b/app/node_modules/modes/at/parser/grammar.pegjs
@@ -3,7 +3,7 @@
 {
 	var lib = require('pegjs-parser/initializer');
 
-	var Node = new lib.NodeInstancier('at');
+	var Node = new lib.NodeInstancier('at', true);
 
 	var blocks = [
 		'cdata',
@@ -25,7 +25,7 @@
 // ------------------------------------------------------------------------ Root
 
 start = ws0:__ nodes:(nodeList __)? {
-	var node = Node('root', line(), column(), offset(), text());
+	var node = Node('root', null, null, offset(), text());
 
 	node.addList('spaces.0', ws0);
 
@@ -56,7 +56,7 @@ nodeList = head:node rest:(__ node)* {
 // The particularity of the text node, is that it is not delimited as other nodes - that is elements, it's just everything that is not an element. So to detect the end of a text, we need to check if an element starts.
 
 text = content:$(!statementStart .)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 statementStart = "${" / "{" / "/*" / "//"
@@ -73,7 +73,7 @@ statement =
 // ----------------------------------------------------------------------- CDATA
 
 cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing {
-	var node = Node('cdata', line(), column(), offset(), text());
+	var node = Node('cdata', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -87,7 +87,7 @@ cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing {
 }
 
 cdataOpening = opening:cdataOpeningOpening ws0:__ closing:cdataOpeningClosing {
-	var node = Node('opening', line(), column(), offset(), text());
+	var node = Node('opening', null, null, offset(), text());
 	node.add('opening', opening);
 	node.addList('spaces.0', ws0);
 	node.add('closing', closing);
@@ -95,25 +95,25 @@ cdataOpening = opening:cdataOpeningOpening ws0:__ closing:cdataOpeningClosing {
 }
 
 cdataOpeningOpening = "{CDATA" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 cdataOpeningClosing = "}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 cdataClosing = "{/CDATA}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 cdataContent = (!cdataClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 // ------------------------------------------------------------------ Expression
 
 expression = opening:expressionOpening ws0:__ content:expressionContent? ws1:__ closing:expressionClosing {
-	var node = Node('expression', line(), column(), offset(), text());
+	var node = Node('expression', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -131,11 +131,11 @@ expression = opening:expressionOpening ws0:__ content:expressionContent? ws1:__ 
 }
 
 expressionOpening = "${" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 expressionClosing = "}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 // expressionContent = blockStatementParam
@@ -143,7 +143,7 @@ expressionClosing = "}" {
 // TODO The following is a work in progress and is not actually used for now
 
 expressionContent = value:expressionValue? modifiers:expressionModifierList? {
-	var node = Node('content', line(), column(), offset(), text());
+	var node = Node('content', null, null, offset(), text());
 
 	if (value != "") {
 		node.add('value', value);
@@ -157,7 +157,7 @@ expressionContent = value:expressionValue? modifiers:expressionModifierList? {
 }
 
 expressionValue = (!expressionModifierPrefix .)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 expressionModifierList = head:expressionModifier rest:(__ expressionModifier)* {
@@ -165,7 +165,7 @@ expressionModifierList = head:expressionModifier rest:(__ expressionModifier)* {
 }
 
 expressionModifier = prefix:expressionModifierPrefix name:expressionModifierName param:expressionModifierParam? {
-	var node = Node('modifier', line(), column(), offset(), text());
+	var node = Node('modifier', null, null, offset(), text());
 	node.add('prefix', prefix);
 	node.add('name', name);
 	if (param != "") {
@@ -175,13 +175,13 @@ expressionModifier = prefix:expressionModifierPrefix name:expressionModifierName
 }
 
 expressionModifierPrefix = "|" {
-	return Node('prefix', line(), column(), offset(), text());
+	return Node('prefix', null, null, offset(), text());
 }
 
 expressionModifierName = id
 
 expressionModifierParam = prefix:expressionModifierParamPrefix value:expressionModifierParamValue? {
-	var node = Node('modifier-param', line(), column(), offset(), text());
+	var node = Node('modifier-param', null, null, offset(), text());
 	node.add('prefix', prefix);
 	if (value != "") {
 		node.add('value', value);
@@ -190,18 +190,18 @@ expressionModifierParam = prefix:expressionModifierParamPrefix value:expressionM
 }
 
 expressionModifierParamPrefix = ":" {
-	return Node('prefix', line(), column(), offset(), text());
+	return Node('prefix', null, null, offset(), text());
 }
 
 // TODO Split param with commas?
 expressionModifierParamValue = (!(expressionModifierPrefix / expressionClosing) .)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 // ---------------------------------------------------------------------- Inline
 
 inline = opening:inlineOpening id:tagId param:inlineStatementParam? closing:inlineClosing {
-	var node = Node('inline', line(), column(), offset(), text());
+	var node = Node('inline', null, null, offset(), text());
 
 	node.add('opening', opening);
 	node.add('id', id);
@@ -216,21 +216,21 @@ inline = opening:inlineOpening id:tagId param:inlineStatementParam? closing:inli
 }
 
 inlineOpening = "{" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 inlineClosing = "/}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 inlineStatementParam = (!inlineClosing bracedContent)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 // ----------------------------------------------------------------------- Block
 
 block = open:opening ws0:__ nodes:(nodeList __)? close:closing {
-	var node = Node('block', line(), column(), offset(), text());
+	var node = Node('block', null, null, offset(), text());
 	node.add('openTag', open);
 	node.addList('spaces.0', ws0);
 	if (nodes !== null) {
@@ -242,7 +242,7 @@ block = open:opening ws0:__ nodes:(nodeList __)? close:closing {
 }
 
 opening = opening:openingOpening id:tagId param:blockStatementParam? closing:openingClosing {
-	var node = Node('opening', line(), column(), offset(), text());
+	var node = Node('opening', null, null, offset(), text());
 
 	node.add('opening', opening);
 	node.add('id', id);
@@ -257,19 +257,19 @@ opening = opening:openingOpening id:tagId param:blockStatementParam? closing:ope
 }
 
 openingOpening = "{" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 openingClosing = "}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 blockStatementParam = (!"}" bracedContent)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 closing = opening:closingOpening id:tagId closing:closingClosing {
-	var node = Node('closing', line(), column(), offset(), text());
+	var node = Node('closing', null, null, offset(), text());
 	node.add('opening', opening);
 	node.add('id', id);
 	node.add('closing', closing);
@@ -277,11 +277,11 @@ closing = opening:closingOpening id:tagId closing:closingClosing {
 }
 
 closingOpening = "{/" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 closingClosing = "}" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 // ------------------------------------------------------------------------- Tag
@@ -292,7 +292,7 @@ tagId =
 	/ id
 
 widgetId = prefix:widgetIdPrefix ns:id separator:widgetNamespaceWidgetSeparator widget:id {
-	var node = Node('widgetId', line(), column(), offset(), text());
+	var node = Node('widgetId', null, null, offset(), text());
 	node.add('prefix', prefix);
 	node.add('namespace', ns);
 	node.add('separator', separator)
@@ -301,11 +301,11 @@ widgetId = prefix:widgetIdPrefix ns:id separator:widgetNamespaceWidgetSeparator 
 }
 
 widgetIdPrefix = "@" {
-	var node = Node('prefix', line(), column(), offset(), text());
+	var node = Node('prefix', null, null, offset(), text());
 }
 
 widgetNamespaceWidgetSeparator = ":" {
-	var node = Node('separator', line(), column(), offset(), text());
+	var node = Node('separator', null, null, offset(), text());
 }
 
 // ----------------------------------------------------------------------- Param
@@ -326,7 +326,7 @@ comment =
 	/ singleLineComment
 
 multiLineComment = opening:multiLineCommentOpening content:multiLineCommentContent? closing:multiLineCommentClosing {
-	var node = Node('multi-line-comment', line(), column(), offset(), text());
+	var node = Node('multi-line-comment', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (content !== null) {
@@ -338,19 +338,19 @@ multiLineComment = opening:multiLineCommentOpening content:multiLineCommentConte
 }
 
 multiLineCommentOpening = "/*" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 multiLineCommentClosing = "*/" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 multiLineCommentContent = (!multiLineCommentClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 singleLineComment =  opening:singleLineCommentOpening content:singleLineCommentContent? closing:singleLineCommentClosing {
-	var node = Node('single-line-comment', line(), column(), offset(), text());
+	var node = Node('single-line-comment', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (content !== null) {
@@ -362,7 +362,7 @@ singleLineComment =  opening:singleLineCommentOpening content:singleLineCommentC
 }
 
 singleLineCommentOpening = "//" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 singleLineCommentClosing = node:eol {
@@ -371,7 +371,7 @@ singleLineCommentClosing = node:eol {
 }
 
 singleLineCommentContent = (!singleLineCommentClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 // --------------------------------------------------------------------- Various
@@ -385,7 +385,7 @@ __ = elements:(wsSequence / comment)* {
 // -------------------------------------------------------------------------- ID
 
 id = idhead idrest* {
-	return Node('id', line(), column(), offset(), text());
+	return Node('id', null, null, offset(), text());
 }
 idhead = idchars
 idrest = digit / idchars
@@ -402,25 +402,25 @@ wsSequence =
 	/ eols
 
 spaces = content:" "+ {
-	var node = Node('spaces', line(), column(), offset(), text());
+	var node = Node('spaces', null, null, offset(), text());
 	node.set('size', content.length);
 	return node;
 }
 
 tabs = content:"\t"+ {
-	var node = Node('tabs', line(), column(), offset(), text());
+	var node = Node('tabs', null, null, offset(), text());
 	node.set('size', content.length);
 	return node;
 }
 
 eols = content:eol+ {
-	var node = Node('eols', line(), column(), offset(), text());
+	var node = Node('eols', null, null, offset(), text());
 	node.addList('eol', content);
 	return node;
 }
 
 eol = value:("\r\n" / "\n" / "\r") {
-	var node = Node('eol', line(), column(), offset(), text());
+	var node = Node('eol', null, null, offset(), text());
 	node.set('value', value);
 	return node;
 }

--- a/app/node_modules/modes/html/parser/grammar.pegjs
+++ b/app/node_modules/modes/html/parser/grammar.pegjs
@@ -3,7 +3,7 @@
 {
 	var lib = require('pegjs-parser/initializer');
 
-	var Node = new lib.NodeInstancier('html');
+	var Node = new lib.NodeInstancier('html', true);
 
 	var blocks = [
 		'cdata',
@@ -27,7 +27,7 @@
 // ------------------------------------------------------------------------ Root
 
 start = ws0:__ nodes:(nodeList __)? {
-	var node = Node('root', line(), column(), offset(), text());
+	var node = Node('root', null, null, offset(), text());
 
 	node.addList('spaces.0', ws0);
 
@@ -58,7 +58,7 @@ nodeList = head:node rest:(__ node)* {
 // The particularity of the text node, is that it is not delimited as other nodes - that is elements, it's just everything that is not an element. So to detect the end of a text, we need to check if an element starts.
 
 text = $(!elementStart .)+ {
-	return Node('text', line(), column(), offset(), text());
+	return Node('text', null, null, offset(), text());
 }
 
 // -------------------------------------------------------------------- Elements
@@ -97,7 +97,7 @@ element =
 	}
 
 elementStart = "<" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 // ---------------------------------------------------------- Directive elements
@@ -112,13 +112,13 @@ directiveElement =
 	}
 
 directiveOpening = "<!" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 // ----------------------------------------------------------------------- CDATA
 
 cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing? {
-	var node = Node('cdata', line(), column(), offset(), text());
+	var node = Node('cdata', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -137,21 +137,21 @@ cdata = opening:cdataOpening content:cdataContent? closing:cdataClosing? {
 }
 
 cdataOpening = "<![CDATA[" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 cdataClosing = "]]>" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 cdataContent = (!cdataClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 // ------------------------------------------------------------------- Directive
 
 directive = opening:directiveOpening ws0:__ id:id? ws1:__ content:directiveContent? closing:directiveClosing? {
-	var node = Node('directive', line(), column(), offset(), text());
+	var node = Node('directive', null, null, offset(), text());
 
 	var errors = [];
 
@@ -185,18 +185,18 @@ directive = opening:directiveOpening ws0:__ id:id? ws1:__ content:directiveConte
 }
 
 directiveClosing = ">" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 directiveContent = (!directiveClosing .)+ {
-	var node = Node('text', line(), column(), offset(), text());
+	var node = Node('text', null, null, offset(), text());
 	return node;
 }
 
 // ---------------------------------------------------------------------- Inline
 
 inline = opening:inlineOpening id:inlineIds ws0:__ attributes:(attributeList __)? closing:inlineClosing? {
-	var node = Node('inline', line(), column(), offset(), text());
+	var node = Node('inline', null, null, offset(), text());
 
 	node.add('opening', opening);
 	node.add('tag', id);
@@ -218,11 +218,11 @@ inline = opening:inlineOpening id:inlineIds ws0:__ attributes:(attributeList __)
 }
 
 inlineOpening = "<" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 inlineClosing = slash:(slash __)? closing:closingAngleBracket {
-	var node = Node('closing', line(), column(), offset(), text());
+	var node = Node('closing', null, null, offset(), text());
 
 	if (slash !== null) {
 		node.add('slash', slash[0]);
@@ -241,7 +241,7 @@ inlineIds = (
 	/ "input"
 	/ "img"
 ) {
-	var node = Node('id', line(), column(), offset(), text());
+	var node = Node('id', null, null, offset(), text());
 	node.set('value', text());
 	return node;
 }
@@ -249,7 +249,7 @@ inlineIds = (
 // ----------------------------------------------------------------------- Block
 
 block = !closing open:opening ws0:__ nodes:(nodeList __)? close:closing? {
-	var node = Node('block', line(), column(), offset(), text());
+	var node = Node('block', null, null, offset(), text());
 	var errors = [];
 
 	node.add('openTag', open);
@@ -274,7 +274,7 @@ block = !closing open:opening ws0:__ nodes:(nodeList __)? close:closing? {
 }
 
 opening = opening:openingOpening id:id? ws0:__ attributes:(attributeList __)? closing:openingClosing? {
-	var node = Node('opening', line(), column(), offset(), text());
+	var node = Node('opening', null, null, offset(), text());
 	var errors = [];
 
 	node.add('opening', opening);
@@ -307,15 +307,15 @@ opening = opening:openingOpening id:id? ws0:__ attributes:(attributeList __)? cl
 }
 
 openingOpening = "<" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 openingClosing = ">" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 closing = opening:closingOpening ws0:__ id:id? ws1:__ closing:closingClosing? {
-	var node = Node('closing', line(), column(), offset(), text());
+	var node = Node('closing', null, null, offset(), text());
 	var errors = [];
 
 	node.add('opening', opening);
@@ -344,18 +344,18 @@ closing = opening:closingOpening ws0:__ id:id? ws1:__ closing:closingClosing? {
 }
 
 closingOpening = "</" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 closingClosing = ">" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 
 // ------------------------------------------------------------------- Attribute
 
 attribute = key:id value:(__ attributeAssignmentOperator __ attrValue?)? {
-	var node = Node('attribute', line(), column(), offset(), text());
+	var node = Node('attribute', null, null, offset(), text());
 
 	node.add('key', key);
 
@@ -375,7 +375,7 @@ attribute = key:id value:(__ attributeAssignmentOperator __ attrValue?)? {
 }
 
 attributeAssignmentOperator = "=" {
-	return Node('binary-operator', line(), column(), offset(), text());
+	return Node('binary-operator', null, null, offset(), text());
 }
 
 // TODO handle white spaces without merging them with attributes
@@ -388,7 +388,7 @@ attrValue =
 	/ unquotedAttr
 
 unquotedAttr = $(idhead idrest*) {
-	var node = Node('value', line(), column(), offset(), text());
+	var node = Node('value', null, null, offset(), text());
 	return node;
 }
 
@@ -399,7 +399,7 @@ string =
 	/ simpleQuoteString
 
 doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent? closing:doubleQuoteStringQuote? {
-	var node = Node('string', line(), column(), offset(), text());
+	var node = Node('string', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -418,16 +418,16 @@ doubleQuoteString = opening:doubleQuoteStringQuote raw:doubleQuoteStringContent?
 }
 
 doubleQuoteStringQuote = '"' {
-	return Node('quotes.double', line(), column(), offset(), text());
+	return Node('quotes.double', null, null, offset(), text());
 }
 
 doubleQuoteStringContent = $(!'"' .)+ {
-	return Node('doubleQuoteString.content', line(), column(), offset(), text());
+	return Node('doubleQuoteString.content', null, null, offset(), text());
 }
 
 
 simpleQuoteString = opening:simpleQuoteStringQuote raw:simpleQuoteStringContent? closing:simpleQuoteStringQuote? {
-	var node = Node('string', line(), column(), offset(), text());
+	var node = Node('string', null, null, offset(), text());
 
 	node.add('opening', opening);
 
@@ -446,18 +446,18 @@ simpleQuoteString = opening:simpleQuoteStringQuote raw:simpleQuoteStringContent?
 }
 
 simpleQuoteStringQuote = "'" {
-	return Node('quotes.simple', line(), column(), offset(), text());
+	return Node('quotes.simple', null, null, offset(), text());
 }
 
 simpleQuoteStringContent = $(!"'" .)+ {
-	return Node('simpleQuoteString.content', line(), column(), offset(), text());
+	return Node('simpleQuoteString.content', null, null, offset(), text());
 }
 
 
 // -------------------------------------------------------------------- Comments
 
 comment = opening:commentOpening content:commentContent? closing:commentClosing? {
-	var node = Node('comment', line(), column(), offset(), text());
+	var node = Node('comment', null, null, offset(), text());
 
 	node.add('opening', opening);
 	if (content !== null) {
@@ -474,15 +474,15 @@ comment = opening:commentOpening content:commentContent? closing:commentClosing?
 }
 
 commentOpening = "<!--" {
-	return Node('opening', line(), column(), offset(), text());
+	return Node('opening', null, null, offset(), text());
 }
 
 commentClosing = "-->" {
-	return Node('closing', line(), column(), offset(), text());
+	return Node('closing', null, null, offset(), text());
 }
 
 commentContent = (!commentClosing .)+ {
-	return Node('content', line(), column(), offset(), text());
+	return Node('content', null, null, offset(), text());
 }
 
 // --------------------------------------------------------------------- Various
@@ -496,7 +496,7 @@ __ = elements:(wsSequence / comment)* {
 // -------------------------------------------------------------------------- ID
 
 id = idhead idrest* {
-	var node = Node('id', line(), column(), offset(), text());
+	var node = Node('id', null, null, offset(), text());
 	return node;
 }
 idhead = idchars
@@ -514,25 +514,25 @@ wsSequence =
 	/ eols
 
 spaces = content:" "+ {
-	var node = Node('spaces', line(), column(), offset(), text());
+	var node = Node('spaces', null, null, offset(), text());
 	node.set('size', content.length);
 	return node;
 }
 
 tabs = content:"\t"+ {
-	var node = Node('tabs', line(), column(), offset(), text());
+	var node = Node('tabs', null, null, offset(), text());
 	node.set('size', content.length);
 	return node;
 }
 
 eols = content:eol+ {
-	var node = Node('eols', line(), column(), offset(), text());
+	var node = Node('eols', null, null, offset(), text());
 	node.addList('eol', content);
 	return node;
 }
 
 eol = value:("\r\n" / "\n" / "\r") {
-	var node = Node('eol', line(), column(), offset(), text());
+	var node = Node('eol', null, null, offset(), text());
 	node.set('value', value);
 	return node;
 }
@@ -545,9 +545,9 @@ digit = [0-9]
 // ------------------------------------------------------------------ Characters
 
 closingAngleBracket = ">" {
-	return Node('brackets.angle.closing', line(), column(), offset(), text());
+	return Node('brackets.angle.closing', null, null, offset(), text());
 }
 
 slash = "/" {
-	return Node('slash', line(), column(), offset(), text());
+	return Node('slash', null, null, offset(), text());
 }

--- a/app/node_modules/modes/node_modules/README.md
+++ b/app/node_modules/modes/node_modules/README.md
@@ -13,7 +13,6 @@ Services:
 Models:
 
 * [`mode.js`](./mode.js): interface to all the services a mode can provide
-* [`node.js`](./node.js): a node is a part of a graph, and in this case it used for one of the representations of a source code
 * [`code.js`](./code.js): provides various models/representations and operations related to a source code
 * [`session.js`](./session.js): a module to handle generically sessions, that is a data store working with ids as input
 

--- a/app/node_modules/modes/node_modules/node/README.md
+++ b/app/node_modules/modes/node_modules/node/README.md
@@ -1,0 +1,19 @@
+A node/graph library tailored for ASTs.
+
+# File system layout
+
+* [`README.md`](./README.md): this current file
+* [`index.js`](./index.js): module entry point
+
+Classes:
+
+* [`node.js`](./node.js): a node is a part of a graph, and in this case it used for one of the representations of a source code
+* [`node-light.js`](./node-light.js): a light implementation of a node
+* [`node-common.js`](./node-common.js): the common class definition of Node for the two implementations above
+* [`location.js`](./location.js): a location for a node
+* [`position.js`](./position.js): a position in a text for a node
+* [`node-type.js`](./node-type.js): a type for a node
+
+# Versioning
+
+To version: _everything_.

--- a/app/node_modules/modes/node_modules/node/index.js
+++ b/app/node_modules/modes/node_modules/node/index.js
@@ -1,0 +1,11 @@
+Object.defineProperty(exports, 'node', {
+	get: function() {
+		return require('./node');
+	}
+});
+
+Object.defineProperty(exports, 'nodeLight', {
+	get: function() {
+		return require('./node-light');
+	}
+});

--- a/app/node_modules/modes/node_modules/node/location.js
+++ b/app/node_modules/modes/node_modules/node/location.js
@@ -1,0 +1,50 @@
+var oop = require('oop').oop;
+
+var Position = require('./position').Position;
+
+
+
+var Location = oop.Class({
+	name: 'Location',
+
+	schema: {
+		inputToSpec: {
+			'Number': 'start'
+		},
+		properties: [
+			{names: ['start', 'beginning', 'from'], ctor: Position},
+			{names: ['end', 'stop', 'to'], ctor: Position}
+		]
+	},
+	statics: {
+
+		/**
+		 * Converts the location into a string following the format
+		 * <start.line>x<start.column>-><end.line>x<end.column>/<start.index>-><end.index>
+		 * @param location {Location}
+		 * @return String
+		 */
+		toJSON: function (location) {
+			var start = location.start, end = location.end;
+
+			var lineColumnOutput = null;
+			if (start.line !== null && start.column !== null && end.line != null && end.column != null) {
+				lineColumnOutput = start.line + "x" + start.column + "->" + end.line + "x" + end.column;
+			}
+
+			var indexesOutput = start.index + "->" + end.index;
+
+			var parts = [];
+			if (lineColumnOutput !== null) {
+				parts.push(lineColumnOutput);
+			}
+			parts.push(indexesOutput);
+
+			return parts.join('/');
+		}
+	}
+});
+
+
+
+exports.Location = Location;

--- a/app/node_modules/modes/node_modules/node/node-common.js
+++ b/app/node_modules/modes/node_modules/node/node-common.js
@@ -5,211 +5,14 @@ var oop = require('oop').oop;
 
 
 
-var NodeType = oop.Class({
-	name: 'Node Type',
-
-	schema: {
-		inputToSpec: {
-			'String': 'language'
-		},
-		properties: [
-			{names: ['language', 'lang']},
-			{names: ['element', 'elmt']}
-		]
-	},
-	statics: {
-
-		/**
-		 * Converts the node type into a string following the format
-		 * <language>:<element>
-		 * @param type {NodeType}
-		 * @return String
-		 */
-		toJSON: function (type) {
-			return type.language == null || type.element == null ? "" : type.language + ":" + type.element;
-		}
-	}
-});
-
-
-var Position = oop.Class({
-	name: 'Position',
-
-	schema: {
-		inputToSpec: {
-			'Number': 'index'
-		},
-		properties: [
-			{names: ['index', 'offset', 'position', 'pos', 'character', 'char']},
-			{names: ['line', 'ln', 'l', 'L']},
-			{names: ['column', 'col', 'c', 'C']}
-		]
-	}
-});
-
-var Location = oop.Class({
-	name: 'Location',
-
-	schema: {
-		inputToSpec: {
-			'Number': 'start'
-		},
-		properties: [
-			{names: ['start', 'beginning', 'from'], ctor: Position},
-			{names: ['end', 'stop', 'to'], ctor: Position}
-		]
-	},
-	statics: {
-
-		/**
-		 * Converts the location into a string following the format
-		 * <start.line>x<start.column>-><end.line>x<end.column>/<start.index>-><end.index>
-		 * @param location {Location}
-		 * @return String
-		 */
-		toJSON: function (location) {
-			var start = location.start, end = location.end;
-			return start.line + "x" + start.column + "->" + end.line + "x" + end.column + "/" + start.index + "->" + end.index;
-		}
-	}
-});
+var NodeType = require('./node-type').NodeType;
+var Location = require('./location').Location;
 
 
 
-
-var Node = oop.Class({
+definition = {
 
 	name: 'Node',
-
-	/***************************************************************************
-	 * Construction
-	 **************************************************************************/
-
-	/**
-	 * @param[in] language {String|Null|Any} The language to which this node belongs to. It is likely to be a string, but you can use any value you want, except `void` because this parameter is required. You can even use `null` to indicate that the language is unknown, or non-relevant for now.
-	 *
-	 * @param[in] element {String|Null|Any} The type of the element for the language this node belongs to. It is likely to be a string, but you can use any value you want, except `void` because this parameter is required. You can even use `null` to indicate that the type is unknown, or non-relevant for now.
-	 *
-	 * @param[in] line {Number} The number of the line where the element starts.
-	 *
-	 * @param[in] column {Number} The number of the column where the element starts.
-	 *
-	 * @param[in] index {Number} The number of the character - 0-based index of the total input - where the element starts.
-	 *
-	 * @todo Maybe we should use the Range type instead of Location, but this might be too heavy for the purpose...
-	 */
-	schema: {
-		properties: [
-			{names: ['type', 'class', 'category', 'cat'], ctor: NodeType, mixed: true},
-			{names: ['location', 'loc', 'range', 'portion', 'piece'], ctor: Location, mixed: true},
-			{names: ['source', 'src', 'input', 'text', 'content']}
-		]
-	},
-
-	init: function() {
-		// Computes line and column indexes for end position
-		if (this.source != null) {
-			var end = this.location.end;
-
-			if (end == null) {
-				end = this.location.end = {};
-			}
-
-			if (end.index == null) {
-				end.index = this.location.start.index + this.source.length;
-			}
-
-			if (end.line == null || end.column == null) {
-				var lines = prelude.lines(this.source);
-				if (lines.length === 0) {
-					lines = [""];
-				}
-
-				if (end.line == null && this.location.start.line != null) {
-					this.location.end.line = this.location.start.line + lines.length - 1;
-				}
-
-				if (end.column == null) {
-					if (lines.length == 1) {
-						this.location.end.column = end.index + 1;
-					} else {
-						this.location.end.column = lines[lines.length - 1].length + 1;
-					}
-				}
-			}
-		}
-
-		this.properties = {};
-		this.flags = {};
-		this.children = [];
-		this.childrenIndex = {};
-		this._index = 0;
-
-	},
-
-	properties: [
-		{names: ['key', 'entry'], desc: {
-			get: function() {
-				return this._key;
-			}
-		}},
-
-		{names: ['index', 'idx'], desc: {
-			get: function() {
-				return this._index;
-			}
-		}},
-
-		{names: ['path'], desc: {
-			/**
-			 * Returns the path to the node, that is the list of nodes leading to it from the root.
-			 *
-			 * In this kind of tree there can be only one path to a node, since there is only one parent per node.
-			 */
-			get: function() {
-				var path;
-				if (this.parent) {
-					path = this.parent.path;
-				} else {
-					path = []
-				}
-
-				path.push(this);
-
-				return path;
-			}
-		}},
-
-		{names: ['branches', 'paths'], desc: {
-			/**
-			 * Branches are all the paths from the root to every leaves.
-			 */
-			get: function() {
-				var branches = [];
-
-				var leaves = this.leaves;
-				for (var i = 0, length = leaves.length; i < length; i++) {
-					branches.push(leaves[i].path);
-				}
-
-				return branches;
-			}
-		}},
-
-		{names: ['flat', 'flatten', 'list', 'lst'], desc: {
-			get: function() {
-				return this.pick(function() {return true;});
-			}
-		}},
-
-		{names: ['leaves', 'edges'], desc: {
-			get: function() {
-				return this.pick(function(node) {
-					return (node.children == null || node.children.length === 0);
-				});
-			}
-		}}
-	],
 
 	statics: {
 
@@ -236,7 +39,7 @@ var Node = oop.Class({
 			}
 			newNodeSpec.source = source.join('');
 
-			return new Node(newNodeSpec);
+			return new this(newNodeSpec);
 		}
 	},
 	methods: {
@@ -311,33 +114,6 @@ var Node = oop.Class({
 		/***********************************************************************
 		 * Children management
 		 **********************************************************************/
-
-		/**
-		 * Adds a child to the children list.
-		 */
-		_pushChild: function(id, child) {
-			if (child == null) {
-				child = {}
-			};
-
-			child = Node.factory(child);
-
-			this.children.push(child);
-
-			// Private properties ----------------------------------------------
-
-			child._index = this.children.length - 1;
-			child._key = id;
-
-			// Properties ------------------------------------------------------
-
-			child.parent = this;
-
-
-			// Return ----------------------------------------------------------
-
-			return child;
-		},
 
 		/**
 		 * Adds a child node with the given id.
@@ -429,15 +205,15 @@ var Node = oop.Class({
 		moveContextLocation: function(offset) {
 			var location = this.location;
 			location.start.index += offset.index;
-			if (location.start.line == 1) { // if the current start location is not on the first line, then the column position will not be impacted
-				location.start.column += offset.column - 1;
-			}
-			location.start.line += offset.line - 1;
+			// if (location.start.line == 1) { // if the current start location is not on the first line, then the column position will not be impacted
+			// 	location.start.column += offset.column - 1;
+			// }
+			// location.start.line += offset.line - 1;
 			location.end.index += offset.index;
-			if (location.end.line == 1) { // if the current end location is not on the first line, then the column position will not be impacted
-				location.end.column += offset.column - 1;
-			}
-			location.end.line += offset.line - 1;
+			// if (location.end.line == 1) { // if the current end location is not on the first line, then the column position will not be impacted
+			// 	location.end.column += offset.column - 1;
+			// }
+			// location.end.line += offset.line - 1;
 			var children = this.children;
 			if (children) {
 				for (var i = 0, len = children.length; i < len; i++) {
@@ -889,7 +665,7 @@ var Node = oop.Class({
 			return output;
 		}
 	}
-});
+};
 
 
 
@@ -908,4 +684,10 @@ function join(part1, sep, part2) {
 
 
 
-exports.Node = Node;
+
+
+Object.defineProperty(exports, 'definition', {
+	get: function() {
+		return Object.create(definition);
+	}
+});

--- a/app/node_modules/modes/node_modules/node/node-light.js
+++ b/app/node_modules/modes/node_modules/node/node-light.js
@@ -1,0 +1,79 @@
+var oop = require('oop').oop;
+
+
+
+
+
+var definition = require('./node-common').definition;
+
+/**
+ * @param[in] language {String|Null|Any} The language to which this node belongs to. It is likely to be a string, but you can use any value you want, except `void` because this parameter is required. You can even use `null` to indicate that the language is unknown, or non-relevant for now.
+ *
+ * @param[in] element {String|Null|Any} The type of the element for the language this node belongs to. It is likely to be a string, but you can use any value you want, except `void` because this parameter is required. You can even use `null` to indicate that the type is unknown, or non-relevant for now.
+ *
+ * @param[in] line {Number} The number of the line where the element starts.
+ *
+ * @param[in] column {Number} The number of the column where the element starts.
+ *
+ * @param[in] index {Number} The number of the character - 0-based index of the total input - where the element starts.
+ *
+ * @todo Maybe we should use the Range type instead of Location, but this might be too heavy for the purpose...
+ */
+definition.init = function(input) {
+	this.type = input.type;
+	this.location = input.location;
+	this.source = input.source;
+
+	// Computes line and column indexes for end position
+	if (this.source != null) {
+		var end = this.location.end;
+
+		if (end == null) {
+			end = this.location.end = {};
+		}
+
+		if (end.index == null) {
+			end.index = this.location.start.index + this.source.length;
+		}
+	}
+
+	this.properties = {};
+	this.flags = {};
+	this.children = [];
+	this.childrenIndex = {};
+	this._index = 0;
+};
+
+
+/***********************************************************************
+ * Children management
+ **********************************************************************/
+
+/**
+ * Adds a child to the children list.
+ */
+definition.methods._pushChild = function(id, child) {
+	this.children.push(child);
+
+	// Private properties ----------------------------------------------
+
+	child._index = this.children.length - 1;
+	child._key = id;
+
+	// Properties ------------------------------------------------------
+
+	child.parent = this;
+
+
+	// Return ----------------------------------------------------------
+
+	return child;
+};
+
+var Node = oop.Class(definition);
+
+
+
+
+
+exports.Node = Node;

--- a/app/node_modules/modes/node_modules/node/node-type.js
+++ b/app/node_modules/modes/node_modules/node/node-type.js
@@ -1,0 +1,33 @@
+var oop = require('oop').oop;
+
+
+
+var NodeType = oop.Class({
+	name: 'Node Type',
+
+	schema: {
+		inputToSpec: {
+			'String': 'language'
+		},
+		properties: [
+			{names: ['language', 'lang']},
+			{names: ['element', 'elmt']}
+		]
+	},
+	statics: {
+
+		/**
+		 * Converts the node type into a string following the format
+		 * <language>:<element>
+		 * @param type {NodeType}
+		 * @return String
+		 */
+		toJSON: function (type) {
+			return type.language == null || type.element == null ? "" : type.language + ":" + type.element;
+		}
+	}
+});
+
+
+
+exports.NodeType = NodeType;

--- a/app/node_modules/modes/node_modules/node/node.js
+++ b/app/node_modules/modes/node_modules/node/node.js
@@ -1,0 +1,165 @@
+var oop = require('oop').oop;
+
+
+
+var NodeType = require('./node-type').NodeType;
+var Location = require('./location').Location;
+
+
+
+
+
+var definition = require('./node-common').definition;
+
+definition.schema = {
+	properties: [
+		{names: ['type', 'class', 'category', 'cat'], ctor: NodeType, mixed: true},
+		{names: ['location', 'loc', 'range', 'portion', 'piece'], ctor: Location, mixed: true},
+		{names: ['source', 'src', 'input', 'text', 'content']}
+	]
+};
+
+definition.init = function() {
+	// Computes line and column indexes for end position
+	if (this.source != null) {
+		var end = this.location.end;
+
+		if (end == null) {
+			end = this.location.end = {};
+		}
+
+		if (end.index == null) {
+			end.index = this.location.start.index + this.source.length;
+		}
+
+		// Too expensive? ---------------------------------------------------
+
+		if (end.line == null || end.column == null) {
+			var lines = prelude.lines(this.source);
+			if (lines.length === 0) {
+				lines = [""];
+			}
+
+			if (end.line == null && this.location.start.line != null) {
+				this.location.end.line = this.location.start.line + lines.length - 1;
+			}
+
+			if (end.column == null) {
+				if (lines.length == 1) {
+					this.location.end.column = end.index + 1;
+				} else {
+					this.location.end.column = lines[lines.length - 1].length + 1;
+				}
+			}
+		}
+	}
+
+	this.properties = {};
+	this.flags = {};
+	this.children = [];
+	this.childrenIndex = {};
+	this._index = 0;
+};
+
+definition.properties = [
+	{names: ['key', 'entry'], desc: {
+		get: function() {
+			return this._key;
+		}
+	}},
+
+	{names: ['index', 'idx'], desc: {
+		get: function() {
+			return this._index;
+		}
+	}},
+
+	{names: ['path'], desc: {
+		/**
+		 * Returns the path to the node, that is the list of nodes leading to it from the root.
+		 *
+		 * In this kind of tree there can be only one path to a node, since there is only one parent per node.
+		 */
+		get: function() {
+			var path;
+			if (this.parent) {
+				path = this.parent.path;
+			} else {
+				path = []
+			}
+
+			path.push(this);
+
+			return path;
+		}
+	}},
+
+	{names: ['branches', 'paths'], desc: {
+		/**
+		 * Branches are all the paths from the root to every leaves.
+		 */
+		get: function() {
+			var branches = [];
+
+			var leaves = this.leaves;
+			for (var i = 0, length = leaves.length; i < length; i++) {
+				branches.push(leaves[i].path);
+			}
+
+			return branches;
+		}
+	}},
+
+	{names: ['flat', 'flatten', 'list', 'lst'], desc: {
+		get: function() {
+			return this.pick(function() {return true;});
+		}
+	}},
+
+	{names: ['leaves', 'edges'], desc: {
+		get: function() {
+			return this.pick(function(node) {
+				return (node.children == null || node.children.length === 0);
+			});
+		}
+	}}
+];
+
+/***********************************************************************
+ * Children management
+ **********************************************************************/
+
+/**
+ * Adds a child to the children list.
+ */
+definition.methods._pushChild = function(id, child) {
+	if (child == null) {
+		child = {}
+	};
+
+	child = Node.factory(child);
+
+	this.children.push(child);
+
+	// Private properties ----------------------------------------------
+
+	child._index = this.children.length - 1;
+	child._key = id;
+
+	// Properties ------------------------------------------------------
+
+	child.parent = this;
+
+
+	// Return ----------------------------------------------------------
+
+	return child;
+};
+
+var Node = oop.Class(definition);
+
+
+
+
+
+exports.Node = Node;

--- a/app/node_modules/modes/node_modules/node/position.js
+++ b/app/node_modules/modes/node_modules/node/position.js
@@ -1,0 +1,22 @@
+var oop = require('oop').oop;
+
+
+
+var Position = oop.Class({
+	name: 'Position',
+
+	schema: {
+		inputToSpec: {
+			'Number': 'index'
+		},
+		properties: [
+			{names: ['index', 'offset', 'position', 'pos', 'character', 'char']},
+			{names: ['line', 'ln', 'l', 'L']},
+			{names: ['column', 'col', 'c', 'C']}
+		]
+	}
+});
+
+
+
+exports.Position = Position;

--- a/app/node_modules/modes/node_modules/pegjs-parser/node-instancier.js
+++ b/app/node_modules/modes/node_modules/pegjs-parser/node-instancier.js
@@ -1,13 +1,15 @@
 var oop = require('oop').oop;
 
+var node = require('node');
+
 
 
 var NodeInstancier = oop.Class({
 	name: 'Node Instancier',
 
-	init: function(language) {
+	init: function(language, lightNode) {
 		this.language = language != null ? language : null;
-		this.NodeClass = require('node').Node;
+		this.NodeClass = lightNode ? node.nodeLight.Node : node.node.Node;
 
 		this.hooks = [];
 	},

--- a/public/actions.js
+++ b/public/actions.js
@@ -266,19 +266,26 @@ var poc = {
 	},
 
 	validate: function() {
-
 		var response = Backend.service(poc.doc, "validate"), msg, err, items;
+
+		var editSession = this.editor.getSession();
+		var doc = editSession.getDocument();
+
 		var annotations = [];
 
-		var types = ['error', 'warning'], keys = ['errors', 'warnings'];
+		var types = ['error', 'warning'];
+		var keys = ['errors', 'warnings'];
 		for (var j = 0; j < types.length; j++) {
 			items = response[keys[j]];
 			for (var i = 0, len = items.length; i < len; i++) {
 				err = items[i];
 				msg = '- ' + err.messages.join('\n- ');
+
+				position = doc.indexToPosition(err.location.start.index);
+
 				annotations.push({
-					row: err.location.start.line - 1,
-					column: err.location.start.column - 1,
+					row: position.row,
+					column: position.column,
 					type: types[j],
 					raw: msg,
 					text: msg
@@ -286,7 +293,8 @@ var poc = {
 			}
 		}
 		poc.introspection.validation = response;
-		this.editor.getSession().setAnnotations(annotations);
+
+		editSession.setAnnotations(annotations);
 	},
 
 // Live preview ----------------------------------------------------------------

--- a/test/app/node_modules/modes/at-html/parser/index/blockHtmlElementClosingWithoutOpening-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockHtmlElementClosingWithoutOpening-output.json
@@ -1,24 +1,24 @@
 {
     "type": "at-html:block-html-element",
-    "location": "1x1->4x5/0->20",
+    "location": "0->20",
     "children": [
         {
             "type": "at-html:closing",
-            "location": "1x1->4x5/0->20",
+            "location": "0->20",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x3/0->2",
+                    "location": "0->2",
                     "children": []
                 },
                 {
                     "type": "at-html:html-id",
-                    "location": "1x3->1x11/2->10",
+                    "location": "2->10",
                     "children": []
                 },
                 {
                     "type": "at-html:eols",
-                    "location": "1x11->4x1/10->16",
+                    "location": "10->16",
                     "children": [],
                     "properties": {
                         "size": 3
@@ -26,7 +26,7 @@
                 },
                 {
                     "type": "at-html:extra-parameters-in-closing-tag",
-                    "location": "4x1->4x20/16->19",
+                    "location": "16->19",
                     "children": [],
                     "properties": {
                         "errors": [
@@ -36,7 +36,7 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "4x4->4x21/19->20",
+                    "location": "19->20",
                     "children": []
                 }
             ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockHtmlElementOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockHtmlElementOne-output.json
@@ -1,57 +1,57 @@
 [
     {
         "type": "at-html:block-html-element",
-        "location": "1x1->1x20/0->19",
+        "location": "0->19",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x7/0->6",
+                "location": "0->6",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:html-id",
-                        "location": "1x2->1x6/1->5",
+                        "location": "1->5",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x6->1x7/5->6",
+                        "location": "5->6",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:block-html-element-content",
-                "location": "1x7->1x13/6->12",
+                "location": "6->12",
                 "children": [
                     {
                         "type": "at-html:text",
-                        "location": "1x7->1x13/6->12",
+                        "location": "6->12",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:closing",
-                "location": "1x13->1x20/12->19",
+                "location": "12->19",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x13->1x15/12->14",
+                        "location": "12->14",
                         "children": []
                     },
                     {
                         "type": "at-html:html-id",
-                        "location": "1x15->1x19/14->18",
+                        "location": "14->18",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x19->1x20/18->19",
+                        "location": "18->19",
                         "children": []
                     }
                 ]
@@ -60,125 +60,125 @@
     },
     {
         "type": "at-html:block-html-element",
-        "location": "1x1->3x14/0->84",
+        "location": "0->84",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x7/0->6",
+                "location": "0->6",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:html-id",
-                        "location": "1x2->1x6/1->5",
+                        "location": "1->5",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x6->1x7/5->6",
+                        "location": "5->6",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:block-html-element-content",
-                "location": "1x7->3x7/6->77",
+                "location": "6->77",
                 "children": [
                     {
                         "type": "at-html:text",
-                        "location": "1x7->1x13/6->12",
+                        "location": "6->12",
                         "children": []
                     },
                     {
                         "type": "at-html:block-html-element",
-                        "location": "1x13->1x51/12->50",
+                        "location": "12->50",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x13->1x19/12->18",
+                                "location": "12->18",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x13->1x14/12->13",
+                                        "location": "12->13",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:html-id",
-                                        "location": "1x14->1x18/13->17",
+                                        "location": "13->17",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x18->1x19/17->18",
+                                        "location": "17->18",
                                         "children": []
                                     }
                                 ]
                             },
                             {
                                 "type": "at-html:block-html-element-content",
-                                "location": "1x19->1x44/18->43",
+                                "location": "18->43",
                                 "children": [
                                     {
                                         "type": "at-html:text",
-                                        "location": "1x19->1x25/18->24",
+                                        "location": "18->24",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:block-html-element",
-                                        "location": "1x25->1x44/24->43",
+                                        "location": "24->43",
                                         "children": [
                                             {
                                                 "type": "at-html:opening",
-                                                "location": "1x25->1x31/24->30",
+                                                "location": "24->30",
                                                 "children": [
                                                     {
                                                         "type": "at-html:opening",
-                                                        "location": "1x25->1x26/24->25",
+                                                        "location": "24->25",
                                                         "children": []
                                                     },
                                                     {
                                                         "type": "at-html:html-id",
-                                                        "location": "1x26->1x30/25->29",
+                                                        "location": "25->29",
                                                         "children": []
                                                     },
                                                     {
                                                         "type": "at-html:closing",
-                                                        "location": "1x30->1x31/29->30",
+                                                        "location": "29->30",
                                                         "children": []
                                                     }
                                                 ]
                                             },
                                             {
                                                 "type": "at-html:block-html-element-content",
-                                                "location": "1x31->1x37/30->36",
+                                                "location": "30->36",
                                                 "children": [
                                                     {
                                                         "type": "at-html:text",
-                                                        "location": "1x31->1x37/30->36",
+                                                        "location": "30->36",
                                                         "children": []
                                                     }
                                                 ]
                                             },
                                             {
                                                 "type": "at-html:closing",
-                                                "location": "1x37->1x44/36->43",
+                                                "location": "36->43",
                                                 "children": [
                                                     {
                                                         "type": "at-html:opening",
-                                                        "location": "1x37->1x39/36->38",
+                                                        "location": "36->38",
                                                         "children": []
                                                     },
                                                     {
                                                         "type": "at-html:html-id",
-                                                        "location": "1x39->1x43/38->42",
+                                                        "location": "38->42",
                                                         "children": []
                                                     },
                                                     {
                                                         "type": "at-html:closing",
-                                                        "location": "1x43->1x44/42->43",
+                                                        "location": "42->43",
                                                         "children": []
                                                     }
                                                 ]
@@ -189,21 +189,21 @@
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x44->1x51/43->50",
+                                "location": "43->50",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x44->1x46/43->45",
+                                        "location": "43->45",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:html-id",
-                                        "location": "1x46->1x50/45->49",
+                                        "location": "45->49",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x50->1x51/49->50",
+                                        "location": "49->50",
                                         "children": []
                                     }
                                 ]
@@ -212,57 +212,57 @@
                     },
                     {
                         "type": "at-html:block-html-element",
-                        "location": "1x51->1x70/50->69",
+                        "location": "50->69",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x51->1x57/50->56",
+                                "location": "50->56",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x51->1x52/50->51",
+                                        "location": "50->51",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:html-id",
-                                        "location": "1x52->1x56/51->55",
+                                        "location": "51->55",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x56->1x57/55->56",
+                                        "location": "55->56",
                                         "children": []
                                     }
                                 ]
                             },
                             {
                                 "type": "at-html:block-html-element-content",
-                                "location": "1x57->1x63/56->62",
+                                "location": "56->62",
                                 "children": [
                                     {
                                         "type": "at-html:text",
-                                        "location": "1x57->1x63/56->62",
+                                        "location": "56->62",
                                         "children": []
                                     }
                                 ]
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x63->1x70/62->69",
+                                "location": "62->69",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x63->1x65/62->64",
+                                        "location": "62->64",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:html-id",
-                                        "location": "1x65->1x69/64->68",
+                                        "location": "64->68",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x69->1x70/68->69",
+                                        "location": "68->69",
                                         "children": []
                                     }
                                 ]
@@ -271,7 +271,7 @@
                     },
                     {
                         "type": "at-html:eols",
-                        "location": "1x70->3x1/69->71",
+                        "location": "69->71",
                         "children": [],
                         "properties": {
                             "size": 2
@@ -279,7 +279,7 @@
                     },
                     {
                         "type": "at-html:tabs",
-                        "location": "3x1->3x73/71->72",
+                        "location": "71->72",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -287,21 +287,21 @@
                     },
                     {
                         "type": "at-html:inline-html-element",
-                        "location": "3x2->3x78/72->77",
+                        "location": "72->77",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "3x2->3x74/72->73",
+                                "location": "72->73",
                                 "children": []
                             },
                             {
                                 "type": "at-html:html-id",
-                                "location": "3x3->3x75/73->74",
+                                "location": "73->74",
                                 "children": []
                             },
                             {
                                 "type": "at-html:spaces",
-                                "location": "3x4->3x5/74->75",
+                                "location": "74->75",
                                 "children": [],
                                 "properties": {
                                     "size": 1
@@ -309,7 +309,7 @@
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "3x5->3x78/75->77",
+                                "location": "75->77",
                                 "children": []
                             }
                         ]
@@ -318,21 +318,21 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "3x7->3x85/77->84",
+                "location": "77->84",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "3x7->3x80/77->79",
+                        "location": "77->79",
                         "children": []
                     },
                     {
                         "type": "at-html:html-id",
-                        "location": "3x9->3x84/79->83",
+                        "location": "79->83",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "3x13->3x85/83->84",
+                        "location": "83->84",
                         "children": []
                     }
                 ]
@@ -341,25 +341,25 @@
     },
     {
         "type": "at-html:block-html-element",
-        "location": "1x1->1x32/0->31",
+        "location": "0->31",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x28/0->27",
+                "location": "0->27",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:html-id",
-                        "location": "1x2->1x6/1->5",
+                        "location": "1->5",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x6->1x7/5->6",
+                        "location": "5->6",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -367,25 +367,25 @@
                     },
                     {
                         "type": "at-html:block-statement",
-                        "location": "1x7->1x27/6->26",
+                        "location": "6->26",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x7->1x17/6->16",
+                                "location": "6->16",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x7->1x8/6->7",
+                                        "location": "6->7",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:at-id",
-                                        "location": "1x8->1x10/7->9",
+                                        "location": "7->9",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:spaces",
-                                        "location": "1x10->1x11/9->10",
+                                        "location": "9->10",
                                         "children": [],
                                         "properties": {
                                             "size": 1
@@ -393,7 +393,7 @@
                                     },
                                     {
                                         "type": "at-html:param",
-                                        "location": "1x11->1x16/10->15",
+                                        "location": "10->15",
                                         "children": [],
                                         "properties": {
                                             "value": "a = 1"
@@ -401,7 +401,7 @@
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x16->1x17/15->16",
+                                        "location": "15->16",
                                         "children": []
                                     }
                                 ],
@@ -414,32 +414,32 @@
                             },
                             {
                                 "type": "at-html:block-statement-content",
-                                "location": "1x17->1x22/16->21",
+                                "location": "16->21",
                                 "children": [
                                     {
                                         "type": "at-html:text",
-                                        "location": "1x17->1x22/16->21",
+                                        "location": "16->21",
                                         "children": []
                                     }
                                 ]
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x22->1x27/21->26",
+                                "location": "21->26",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x22->1x24/21->23",
+                                        "location": "21->23",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:at-id",
-                                        "location": "1x24->1x26/23->25",
+                                        "location": "23->25",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x26->1x27/25->26",
+                                        "location": "25->26",
                                         "children": []
                                     }
                                 ]
@@ -448,7 +448,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x27->1x28/26->27",
+                        "location": "26->27",
                         "children": []
                     }
                 ],
@@ -460,21 +460,21 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x28->1x32/27->31",
+                "location": "27->31",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x28->1x30/27->29",
+                        "location": "27->29",
                         "children": []
                     },
                     {
                         "type": "at-html:html-id",
-                        "location": "1x30->1x31/29->30",
+                        "location": "29->30",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x31->1x32/30->31",
+                        "location": "30->31",
                         "children": []
                     }
                 ],
@@ -488,20 +488,20 @@
     },
     {
         "type": "at-html:block-html-element",
-        "location": "1x1->4x5/0->66",
+        "location": "0->66",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x24/0->23",
+                "location": "0->23",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x2->1x3/1->2",
+                        "location": "1->2",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -509,25 +509,25 @@
                     },
                     {
                         "type": "at-html:block-statement",
-                        "location": "1x3->1x23/2->22",
+                        "location": "2->22",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x3->1x13/2->12",
+                                "location": "2->12",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x3->1x4/2->3",
+                                        "location": "2->3",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:at-id",
-                                        "location": "1x4->1x6/3->5",
+                                        "location": "3->5",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:spaces",
-                                        "location": "1x6->1x7/5->6",
+                                        "location": "5->6",
                                         "children": [],
                                         "properties": {
                                             "size": 1
@@ -535,7 +535,7 @@
                                     },
                                     {
                                         "type": "at-html:param",
-                                        "location": "1x7->1x12/6->11",
+                                        "location": "6->11",
                                         "children": [],
                                         "properties": {
                                             "value": "a = 1"
@@ -543,7 +543,7 @@
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x12->1x13/11->12",
+                                        "location": "11->12",
                                         "children": []
                                     }
                                 ],
@@ -556,32 +556,32 @@
                             },
                             {
                                 "type": "at-html:block-statement-content",
-                                "location": "1x13->1x18/12->17",
+                                "location": "12->17",
                                 "children": [
                                     {
                                         "type": "at-html:text",
-                                        "location": "1x13->1x18/12->17",
+                                        "location": "12->17",
                                         "children": []
                                     }
                                 ]
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x18->1x23/17->22",
+                                "location": "17->22",
                                 "children": [
                                     {
                                         "type": "at-html:opening",
-                                        "location": "1x18->1x20/17->19",
+                                        "location": "17->19",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:at-id",
-                                        "location": "1x20->1x22/19->21",
+                                        "location": "19->21",
                                         "children": []
                                     },
                                     {
                                         "type": "at-html:closing",
-                                        "location": "1x22->1x23/21->22",
+                                        "location": "21->22",
                                         "children": []
                                     }
                                 ]
@@ -590,7 +590,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x23->1x24/22->23",
+                        "location": "22->23",
                         "children": []
                     }
                 ],
@@ -603,25 +603,25 @@
             },
             {
                 "type": "at-html:block-html-element-content",
-                "location": "1x24->4x1/23->62",
+                "location": "23->62",
                 "children": [
                     {
                         "type": "at-html:inline-statement",
-                        "location": "1x24->1x37/23->36",
+                        "location": "23->36",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x24->1x25/23->24",
+                                "location": "23->24",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-id",
-                                "location": "1x25->1x28/24->27",
+                                "location": "24->27",
                                 "children": []
                             },
                             {
                                 "type": "at-html:spaces",
-                                "location": "1x28->1x29/27->28",
+                                "location": "27->28",
                                 "children": [],
                                 "properties": {
                                     "size": 1
@@ -629,7 +629,7 @@
                             },
                             {
                                 "type": "at-html:param",
-                                "location": "1x29->1x35/28->34",
+                                "location": "28->34",
                                 "children": [],
                                 "properties": {
                                     "value": "a = 56"
@@ -637,35 +637,35 @@
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x35->1x37/34->36",
+                                "location": "34->36",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:multi-line-comment",
-                        "location": "1x37->1x57/36->56",
+                        "location": "36->56",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x37->1x39/36->38",
+                                "location": "36->38",
                                 "children": []
                             },
                             {
                                 "type": "at-html:content",
-                                "location": "1x39->1x55/38->54",
+                                "location": "38->54",
                                 "children": []
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x55->1x57/54->56",
+                                "location": "54->56",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:eols",
-                        "location": "1x57->3x1/56->58",
+                        "location": "56->58",
                         "children": [],
                         "properties": {
                             "size": 2
@@ -673,23 +673,23 @@
                     },
                     {
                         "type": "at-html:single-line-comment",
-                        "location": "3x1->3x62/58->61",
+                        "location": "58->61",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "3x1->3x61/58->60",
+                                "location": "58->60",
                                 "children": []
                             },
                             {
                                 "type": "at-html:content",
-                                "location": "3x3->3x62/60->61",
+                                "location": "60->61",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:eols",
-                        "location": "3x4->4x1/61->62",
+                        "location": "61->62",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -699,21 +699,21 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "4x1->4x67/62->66",
+                "location": "62->66",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "4x1->4x65/62->64",
+                        "location": "62->64",
                         "children": []
                     },
                     {
                         "type": "at-html:html-id",
-                        "location": "4x3->4x66/64->65",
+                        "location": "64->65",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "4x4->4x67/65->66",
+                        "location": "65->66",
                         "children": []
                     }
                 ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockHtmlElementOpeningWithoutClosing-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockHtmlElementOpeningWithoutClosing-output.json
@@ -1,24 +1,24 @@
 {
     "type": "at-html:block-html-element",
-    "location": "1x1->1x41/0->40",
+    "location": "0->40",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x41/0->40",
+            "location": "0->40",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x2/0->1",
+                    "location": "0->1",
                     "children": []
                 },
                 {
                     "type": "at-html:html-id",
-                    "location": "1x2->1x12/1->11",
+                    "location": "1->11",
                     "children": []
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "1x12->1x13/11->12",
+                    "location": "11->12",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -26,21 +26,21 @@
                 },
                 {
                     "type": "at-html:text",
-                    "location": "1x13->1x35/12->34",
+                    "location": "12->34",
                     "children": []
                 },
                 {
                     "type": "at-html:expression",
-                    "location": "1x35->1x40/34->39",
+                    "location": "34->39",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x35->1x37/34->36",
+                            "location": "34->36",
                             "children": []
                         },
                         {
                             "type": "at-html:param",
-                            "location": "1x37->1x39/36->38",
+                            "location": "36->38",
                             "children": [],
                             "properties": {
                                 "value": "my"
@@ -48,14 +48,14 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x39->1x40/38->39",
+                            "location": "38->39",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x40->1x41/39->40",
+                    "location": "39->40",
                     "children": []
                 }
             ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockHtmlTagClosing-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockHtmlTagClosing-output.json
@@ -1,21 +1,21 @@
 [
     {
         "type": "at-html:closing",
-        "location": "1x1->3x2/0->22",
+        "location": "0->22",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:html-id",
-                "location": "1x3->1x7/2->6",
+                "location": "2->6",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x7->1x8/6->7",
+                "location": "6->7",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -23,7 +23,7 @@
             },
             {
                 "type": "at-html:extra-parameters-in-closing-tag",
-                "location": "1x8->3x1/7->21",
+                "location": "7->21",
                 "children": [],
                 "properties": {
                     "errors": [
@@ -33,23 +33,23 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "3x1->3x23/21->22",
+                "location": "21->22",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x3->1x4/2->3",
+                "location": "2->3",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -57,49 +57,49 @@
             },
             {
                 "type": "at-html:html-id",
-                "location": "1x4->1x11/3->10",
+                "location": "3->10",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x11->1x12/10->11",
+                "location": "10->11",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x6/0->5",
+        "location": "0->5",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:html-id",
-                "location": "1x3->1x5/2->4",
+                "location": "2->4",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x5->1x6/4->5",
+                "location": "4->5",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x50/0->49",
+        "location": "0->49",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x3->1x4/2->3",
+                "location": "2->3",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -107,12 +107,12 @@
             },
             {
                 "type": "at-html:html-id",
-                "location": "1x4->1x13/3->12",
+                "location": "3->12",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x13->1x14/12->13",
+                "location": "12->13",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -120,7 +120,7 @@
             },
             {
                 "type": "at-html:extra-parameters-in-closing-tag",
-                "location": "1x14->1x49/13->48",
+                "location": "13->48",
                 "children": [],
                 "properties": {
                     "errors": [
@@ -130,23 +130,23 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x49->1x50/48->49",
+                "location": "48->49",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x4/0->3",
+        "location": "0->3",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x3->1x4/2->3",
+                "location": "2->3",
                 "children": []
             }
         ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockHtmlTagOpening-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockHtmlTagOpening-output.json
@@ -1,37 +1,37 @@
 [
     {
         "type": "at-html:opening",
-        "location": "1x1->1x7/0->6",
+        "location": "0->6",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:html-id",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x6->1x7/5->6",
+                "location": "5->6",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x3/0->2",
+        "location": "0->2",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": []
             }
         ],
@@ -43,16 +43,16 @@
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x23/0->22",
+        "location": "0->22",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -60,12 +60,12 @@
             },
             {
                 "type": "at-html:text",
-                "location": "1x3->1x22/2->21",
+                "location": "2->21",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x22->1x23/21->22",
+                "location": "21->22",
                 "children": []
             }
         ],
@@ -77,16 +77,16 @@
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x51/0->50",
+        "location": "0->50",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -94,25 +94,25 @@
             },
             {
                 "type": "at-html:block-statement",
-                "location": "1x3->1x50/2->49",
+                "location": "2->49",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x3->1x25/2->24",
+                        "location": "2->24",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x3->1x4/2->3",
+                                "location": "2->3",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-id",
-                                "location": "1x4->1x6/3->5",
+                                "location": "3->5",
                                 "children": []
                             },
                             {
                                 "type": "at-html:spaces",
-                                "location": "1x6->1x7/5->6",
+                                "location": "5->6",
                                 "children": [],
                                 "properties": {
                                     "size": 1
@@ -120,7 +120,7 @@
                             },
                             {
                                 "type": "at-html:param",
-                                "location": "1x7->1x24/6->23",
+                                "location": "6->23",
                                 "children": [],
                                 "properties": {
                                     "value": "fruit.length >  1"
@@ -128,7 +128,7 @@
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x24->1x25/23->24",
+                                "location": "23->24",
                                 "children": []
                             }
                         ],
@@ -141,11 +141,11 @@
                     },
                     {
                         "type": "at-html:block-statement-content",
-                        "location": "1x25->1x45/24->44",
+                        "location": "24->44",
                         "children": [
                             {
                                 "type": "at-html:spaces",
-                                "location": "1x25->1x26/24->25",
+                                "location": "24->25",
                                 "children": [],
                                 "properties": {
                                     "size": 1
@@ -153,28 +153,28 @@
                             },
                             {
                                 "type": "at-html:text",
-                                "location": "1x26->1x45/25->44",
+                                "location": "25->44",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x45->1x50/44->49",
+                        "location": "44->49",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x45->1x47/44->46",
+                                "location": "44->46",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-id",
-                                "location": "1x47->1x49/46->48",
+                                "location": "46->48",
                                 "children": []
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x49->1x50/48->49",
+                                "location": "48->49",
                                 "children": []
                             }
                         ]
@@ -183,7 +183,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x50->1x51/49->50",
+                "location": "49->50",
                 "children": []
             }
         ],
@@ -195,21 +195,21 @@
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x76/0->75",
+        "location": "0->75",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:html-id",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x6->1x7/5->6",
+                "location": "5->6",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -217,21 +217,21 @@
             },
             {
                 "type": "at-html:text",
-                "location": "1x7->1x14/6->13",
+                "location": "6->13",
                 "children": []
             },
             {
                 "type": "at-html:expression",
-                "location": "1x14->1x26/13->25",
+                "location": "13->25",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x14->1x16/13->15",
+                        "location": "13->15",
                         "children": []
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x16->1x25/15->24",
+                        "location": "15->24",
                         "children": [],
                         "properties": {
                             "value": "className"
@@ -239,37 +239,37 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x25->1x26/24->25",
+                        "location": "24->25",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:text",
-                "location": "1x26->1x28/25->27",
+                "location": "25->27",
                 "children": []
             },
             {
                 "type": "at-html:block-statement",
-                "location": "1x28->1x75/27->74",
+                "location": "27->74",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x28->1x50/27->49",
+                        "location": "27->49",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x28->1x29/27->28",
+                                "location": "27->28",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-id",
-                                "location": "1x29->1x31/28->30",
+                                "location": "28->30",
                                 "children": []
                             },
                             {
                                 "type": "at-html:spaces",
-                                "location": "1x31->1x32/30->31",
+                                "location": "30->31",
                                 "children": [],
                                 "properties": {
                                     "size": 1
@@ -277,7 +277,7 @@
                             },
                             {
                                 "type": "at-html:param",
-                                "location": "1x32->1x49/31->48",
+                                "location": "31->48",
                                 "children": [],
                                 "properties": {
                                     "value": "fruit.length >  1"
@@ -285,7 +285,7 @@
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x49->1x50/48->49",
+                                "location": "48->49",
                                 "children": []
                             }
                         ],
@@ -298,11 +298,11 @@
                     },
                     {
                         "type": "at-html:block-statement-content",
-                        "location": "1x50->1x70/49->69",
+                        "location": "49->69",
                         "children": [
                             {
                                 "type": "at-html:spaces",
-                                "location": "1x50->1x51/49->50",
+                                "location": "49->50",
                                 "children": [],
                                 "properties": {
                                     "size": 1
@@ -310,28 +310,28 @@
                             },
                             {
                                 "type": "at-html:text",
-                                "location": "1x51->1x70/50->69",
+                                "location": "50->69",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x70->1x75/69->74",
+                        "location": "69->74",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "1x70->1x72/69->71",
+                                "location": "69->71",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-id",
-                                "location": "1x72->1x74/71->73",
+                                "location": "71->73",
                                 "children": []
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "1x74->1x75/73->74",
+                                "location": "73->74",
                                 "children": []
                             }
                         ]
@@ -340,7 +340,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x75->1x76/74->75",
+                "location": "74->75",
                 "children": []
             }
         ]

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementClosing-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementClosing-output.json
@@ -1,42 +1,42 @@
 [
     {
         "type": "at-html:closing",
-        "location": "1x1->1x9/0->8",
+        "location": "0->8",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x3->1x8/2->7",
+                "location": "2->7",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x8->1x9/7->8",
+                "location": "7->8",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x18/0->17",
+        "location": "0->17",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x3->1x8/2->7",
+                "location": "2->7",
                 "children": []
             },
             {
                 "type": "at-html:extra-parameters-in-closing-tag",
-                "location": "1x8->1x17/7->16",
+                "location": "7->16",
                 "children": [],
                 "properties": {
                     "errors": [
@@ -46,28 +46,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x17->1x18/16->17",
+                "location": "16->17",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x3->1x11/2->10",
+                "location": "2->10",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x11->1x12/10->11",
+                "location": "10->11",
                 "children": []
             }
         ],
@@ -79,21 +79,21 @@
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x7/0->6",
+        "location": "0->6",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x3->1x6/2->5",
+                "location": "2->5",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x6->1x7/5->6",
+                "location": "5->6",
                 "children": []
             }
         ],
@@ -105,21 +105,21 @@
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x9/0->8",
+        "location": "0->8",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x3->1x8/2->7",
+                "location": "2->7",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x8->1x9/7->8",
+                "location": "7->8",
                 "children": []
             }
         ]

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementClosingWithoutId-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementClosingWithoutId-output.json
@@ -1,16 +1,16 @@
 [
     {
         "type": "at-html:closing",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:extra-parameters-in-closing-tag",
-                "location": "1x3->1x11/2->10",
+                "location": "2->10",
                 "children": [],
                 "properties": {
                     "errors": [
@@ -20,7 +20,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x11->1x12/10->11",
+                "location": "10->11",
                 "children": []
             }
         ],
@@ -32,16 +32,16 @@
     },
     {
         "type": "at-html:closing",
-        "location": "1x1->1x4/0->3",
+        "location": "0->3",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x3->1x4/2->3",
+                "location": "2->3",
                 "children": []
             }
         ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementClosingWithoutOpening-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementClosingWithoutOpening-output.json
@@ -1,25 +1,25 @@
 [
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x9/0->8",
+        "location": "0->8",
         "children": [
             {
                 "type": "at-html:closing",
-                "location": "1x1->1x9/0->8",
+                "location": "0->8",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x3/0->2",
+                        "location": "0->2",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x3->1x8/2->7",
+                        "location": "2->7",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x8->1x9/7->8",
+                        "location": "7->8",
                         "children": []
                     }
                 ],
@@ -33,25 +33,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x18/0->17",
+        "location": "0->17",
         "children": [
             {
                 "type": "at-html:closing",
-                "location": "1x1->1x18/0->17",
+                "location": "0->17",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x3/0->2",
+                        "location": "0->2",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x3->1x8/2->7",
+                        "location": "2->7",
                         "children": []
                     },
                     {
                         "type": "at-html:extra-parameters-in-closing-tag",
-                        "location": "1x8->1x17/7->16",
+                        "location": "7->16",
                         "children": [],
                         "properties": {
                             "errors": [
@@ -61,7 +61,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x17->1x18/16->17",
+                        "location": "16->17",
                         "children": []
                     }
                 ],
@@ -75,25 +75,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:closing",
-                "location": "1x1->1x12/0->11",
+                "location": "0->11",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x3/0->2",
+                        "location": "0->2",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x3->1x11/2->10",
+                        "location": "2->10",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x11->1x12/10->11",
+                        "location": "10->11",
                         "children": []
                     }
                 ],
@@ -108,25 +108,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x7/0->6",
+        "location": "0->6",
         "children": [
             {
                 "type": "at-html:closing",
-                "location": "1x1->1x7/0->6",
+                "location": "0->6",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x3/0->2",
+                        "location": "0->2",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x3->1x6/2->5",
+                        "location": "2->5",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x6->1x7/5->6",
+                        "location": "5->6",
                         "children": []
                     }
                 ],
@@ -141,25 +141,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x9/0->8",
+        "location": "0->8",
         "children": [
             {
                 "type": "at-html:closing",
-                "location": "1x1->1x9/0->8",
+                "location": "0->8",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x3/0->2",
+                        "location": "0->2",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x3->1x8/2->7",
+                        "location": "2->7",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x8->1x9/7->8",
+                        "location": "7->8",
                         "children": []
                     }
                 ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementClosingWithoutOpeningInHtmlBlock-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementClosingWithoutOpeningInHtmlBlock-output.json
@@ -1,35 +1,35 @@
 {
     "type": "at-html:block-html-element",
-    "location": "1x1->3x9/0->24",
+    "location": "0->24",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x8/0->7",
+            "location": "0->7",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x2/0->1",
+                    "location": "0->1",
                     "children": []
                 },
                 {
                     "type": "at-html:html-id",
-                    "location": "1x2->1x7/1->6",
+                    "location": "1->6",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x7->1x8/6->7",
+                    "location": "6->7",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:block-html-element-content",
-            "location": "1x8->3x1/7->16",
+            "location": "7->16",
             "children": [
                 {
                     "type": "at-html:eols",
-                    "location": "1x8->2x1/7->9",
+                    "location": "7->9",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -37,7 +37,7 @@
                 },
                 {
                     "type": "at-html:tabs",
-                    "location": "2x1->2x11/9->10",
+                    "location": "9->10",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -45,25 +45,25 @@
                 },
                 {
                     "type": "at-html:block-statement",
-                    "location": "2x2->2x15/10->14",
+                    "location": "10->14",
                     "children": [
                         {
                             "type": "at-html:closing",
-                            "location": "2x2->2x15/10->14",
+                            "location": "10->14",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "2x2->2x13/10->12",
+                                    "location": "10->12",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:at-id",
-                                    "location": "2x4->2x14/12->13",
+                                    "location": "12->13",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "2x5->2x15/13->14",
+                                    "location": "13->14",
                                     "children": []
                                 }
                             ],
@@ -78,7 +78,7 @@
                 },
                 {
                     "type": "at-html:eols",
-                    "location": "2x6->3x1/14->16",
+                    "location": "14->16",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -88,21 +88,21 @@
         },
         {
             "type": "at-html:closing",
-            "location": "3x1->3x25/16->24",
+            "location": "16->24",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "3x1->3x19/16->18",
+                    "location": "16->18",
                     "children": []
                 },
                 {
                     "type": "at-html:html-id",
-                    "location": "3x3->3x24/18->23",
+                    "location": "18->23",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "3x8->3x25/23->24",
+                    "location": "23->24",
                     "children": []
                 }
             ]

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementOne-output.json
@@ -1,24 +1,24 @@
 {
     "type": "at-html:block-statement",
-    "location": "1x1->6x11/0->83",
+    "location": "0->83",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x36/0->35",
+            "location": "0->35",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x2/0->1",
+                    "location": "0->1",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "1x2->1x9/1->8",
+                    "location": "1->8",
                     "children": []
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "1x9->1x10/8->9",
+                    "location": "8->9",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -26,7 +26,7 @@
                 },
                 {
                     "type": "at-html:param",
-                    "location": "1x10->1x35/9->34",
+                    "location": "9->34",
                     "children": [],
                     "properties": {
                         "value": "pax inView passengersView"
@@ -34,18 +34,18 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x35->1x36/34->35",
+                    "location": "34->35",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:block-statement-content",
-            "location": "1x36->6x1/35->73",
+            "location": "35->73",
             "children": [
                 {
                     "type": "at-html:eols",
-                    "location": "1x36->2x1/35->37",
+                    "location": "35->37",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -53,7 +53,7 @@
                 },
                 {
                     "type": "at-html:tabs",
-                    "location": "2x1->2x39/37->38",
+                    "location": "37->38",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -61,33 +61,33 @@
                 },
                 {
                     "type": "at-html:text",
-                    "location": "2x2->3x2/38->58",
+                    "location": "38->58",
                     "children": []
                 },
                 {
                     "type": "at-html:multi-line-comment",
-                    "location": "3x2->3x68/58->67",
+                    "location": "58->67",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "3x2->3x61/58->60",
+                            "location": "58->60",
                             "children": []
                         },
                         {
                             "type": "at-html:content",
-                            "location": "3x4->3x66/60->65",
+                            "location": "60->65",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "3x9->3x68/65->67",
+                            "location": "65->67",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:eols",
-                    "location": "3x11->6x1/67->73",
+                    "location": "67->73",
                     "children": [],
                     "properties": {
                         "size": 3
@@ -97,21 +97,21 @@
         },
         {
             "type": "at-html:closing",
-            "location": "6x1->6x84/73->83",
+            "location": "73->83",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "6x1->6x76/73->75",
+                    "location": "73->75",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "6x3->6x83/75->82",
+                    "location": "75->82",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "6x10->6x84/82->83",
+                    "location": "82->83",
                     "children": []
                 }
             ]

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementOpening-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementOpening-output.json
@@ -1,21 +1,21 @@
 [
     {
         "type": "at-html:opening",
-        "location": "1x1->1x17/0->16",
+        "location": "0->16",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x9/1->8",
+                "location": "1->8",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x9->1x10/8->9",
+                "location": "8->9",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -23,7 +23,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x10->1x16/9->15",
+                "location": "9->15",
                 "children": [],
                 "properties": {
                     "value": "params",
@@ -34,28 +34,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x16->1x17/15->16",
+                "location": "15->16",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x34/0->33",
+        "location": "0->33",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x9/1->8",
+                "location": "1->8",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x9->1x10/8->9",
+                "location": "8->9",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -63,7 +63,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x10->1x33/9->32",
+                "location": "9->32",
                 "children": [],
                 "properties": {
                     "value": "item inArray data.items"
@@ -71,28 +71,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x33->1x34/32->33",
+                "location": "32->33",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x46/0->45",
+        "location": "0->45",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x4/1->3",
+                "location": "1->3",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x4->1x5/3->4",
+                "location": "3->4",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -100,7 +100,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x5->1x44/4->43",
+                "location": "4->43",
                 "children": [],
                 "properties": {
                     "value": "checkCondition({with:'this parameter'})"
@@ -108,7 +108,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x44->1x45/43->44",
+                "location": "43->44",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -116,28 +116,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x45->1x46/44->45",
+                "location": "44->45",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x17/0->16",
+        "location": "0->16",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x7/1->6",
+                "location": "1->6",
                 "children": []
             },
             {
                 "type": "at-html:param",
-                "location": "1x7->1x16/6->15",
+                "location": "6->15",
                 "children": [],
                 "properties": {
                     "value": "(a, b, c)",
@@ -148,28 +148,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x16->1x17/15->16",
+                "location": "15->16",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x25/0->24",
+        "location": "0->24",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x7/1->6",
+                "location": "1->6",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x7->1x8/6->7",
+                "location": "6->7",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -177,7 +177,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x8->1x24/7->23",
+                "location": "7->23",
                 "children": [],
                 "properties": {
                     "value": "myMacro(a, b, c)"
@@ -185,28 +185,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x24->1x25/23->24",
+                "location": "23->24",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x20/0->19",
+        "location": "0->19",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x16/1->15",
+                "location": "1->15",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x16->1x17/15->16",
+                "location": "15->16",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -214,7 +214,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x17->1x19/16->18",
+                "location": "16->18",
                 "children": [],
                 "properties": {
                     "value": "{}"
@@ -222,7 +222,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x19->1x20/18->19",
+                "location": "18->19",
                 "children": []
             }
         ],
@@ -234,21 +234,21 @@
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x22/0->21",
+        "location": "0->21",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x14/1->13",
+                "location": "1->13",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x14->1x15/13->14",
+                "location": "13->14",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -256,7 +256,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x15->1x20/14->19",
+                "location": "14->19",
                 "children": [],
                 "properties": {
                     "value": "v = 1"
@@ -264,7 +264,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x20->1x21/19->20",
+                "location": "19->20",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -272,7 +272,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x21->1x22/20->21",
+                "location": "20->21",
                 "children": []
             }
         ],
@@ -284,42 +284,42 @@
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x8/0->7",
+        "location": "0->7",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x7/1->6",
+                "location": "1->6",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x7->1x8/6->7",
+                "location": "6->7",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x16/0->15",
+        "location": "0->15",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x7/1->6",
+                "location": "1->6",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x7->1x8/6->7",
+                "location": "6->7",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -327,7 +327,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x8->1x15/7->14",
+                "location": "7->14",
                 "children": [],
                 "properties": {
                     "value": "dkjfkdk",
@@ -338,7 +338,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x15->1x16/14->15",
+                "location": "14->15",
                 "children": []
             }
         ]

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementOpeningWithoutClosing-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementOpeningWithoutClosing-output.json
@@ -1,25 +1,25 @@
 [
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x17/0->16",
+        "location": "0->16",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x17/0->16",
+                "location": "0->16",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x9/1->8",
+                        "location": "1->8",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x9->1x10/8->9",
+                        "location": "8->9",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -27,7 +27,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x10->1x16/9->15",
+                        "location": "9->15",
                         "children": [],
                         "properties": {
                             "value": "params",
@@ -38,7 +38,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x16->1x17/15->16",
+                        "location": "15->16",
                         "children": []
                     }
                 ],
@@ -52,25 +52,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x34/0->33",
+        "location": "0->33",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x34/0->33",
+                "location": "0->33",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x9/1->8",
+                        "location": "1->8",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x9->1x10/8->9",
+                        "location": "8->9",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -78,7 +78,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x10->1x33/9->32",
+                        "location": "9->32",
                         "children": [],
                         "properties": {
                             "value": "item inArray data.items"
@@ -86,7 +86,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x33->1x34/32->33",
+                        "location": "32->33",
                         "children": []
                     }
                 ],
@@ -100,25 +100,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x46/0->45",
+        "location": "0->45",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x46/0->45",
+                "location": "0->45",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x4/1->3",
+                        "location": "1->3",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x4->1x5/3->4",
+                        "location": "3->4",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -126,7 +126,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x5->1x44/4->43",
+                        "location": "4->43",
                         "children": [],
                         "properties": {
                             "value": "checkCondition({with:'this parameter'})"
@@ -134,7 +134,7 @@
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x44->1x45/43->44",
+                        "location": "43->44",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -142,7 +142,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x45->1x46/44->45",
+                        "location": "44->45",
                         "children": []
                     }
                 ],
@@ -156,25 +156,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x17/0->16",
+        "location": "0->16",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x17/0->16",
+                "location": "0->16",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x7/1->6",
+                        "location": "1->6",
                         "children": []
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x7->1x16/6->15",
+                        "location": "6->15",
                         "children": [],
                         "properties": {
                             "value": "(a, b, c)",
@@ -185,7 +185,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x16->1x17/15->16",
+                        "location": "15->16",
                         "children": []
                     }
                 ],
@@ -199,25 +199,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x25/0->24",
+        "location": "0->24",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x25/0->24",
+                "location": "0->24",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x7/1->6",
+                        "location": "1->6",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x7->1x8/6->7",
+                        "location": "6->7",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -225,7 +225,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x8->1x24/7->23",
+                        "location": "7->23",
                         "children": [],
                         "properties": {
                             "value": "myMacro(a, b, c)"
@@ -233,7 +233,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x24->1x25/23->24",
+                        "location": "23->24",
                         "children": []
                     }
                 ],
@@ -247,25 +247,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x20/0->19",
+        "location": "0->19",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x20/0->19",
+                "location": "0->19",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x16/1->15",
+                        "location": "1->15",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x16->1x17/15->16",
+                        "location": "15->16",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -273,7 +273,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x17->1x19/16->18",
+                        "location": "16->18",
                         "children": [],
                         "properties": {
                             "value": "{}"
@@ -281,7 +281,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x19->1x20/18->19",
+                        "location": "18->19",
                         "children": []
                     }
                 ],
@@ -296,25 +296,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x22/0->21",
+        "location": "0->21",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x22/0->21",
+                "location": "0->21",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x14/1->13",
+                        "location": "1->13",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x14->1x15/13->14",
+                        "location": "13->14",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -322,7 +322,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x15->1x20/14->19",
+                        "location": "14->19",
                         "children": [],
                         "properties": {
                             "value": "v = 1"
@@ -330,7 +330,7 @@
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x20->1x21/19->20",
+                        "location": "19->20",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -338,7 +338,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x21->1x22/20->21",
+                        "location": "20->21",
                         "children": []
                     }
                 ],
@@ -353,25 +353,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x8/0->7",
+        "location": "0->7",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x8/0->7",
+                "location": "0->7",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x7/1->6",
+                        "location": "1->6",
                         "children": []
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x7->1x8/6->7",
+                        "location": "6->7",
                         "children": []
                     }
                 ],
@@ -385,25 +385,25 @@
     },
     {
         "type": "at-html:block-statement",
-        "location": "1x1->1x16/0->15",
+        "location": "0->15",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x16/0->15",
+                "location": "0->15",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-id",
-                        "location": "1x2->1x7/1->6",
+                        "location": "1->6",
                         "children": []
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x7->1x8/6->7",
+                        "location": "6->7",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -411,7 +411,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x8->1x15/7->14",
+                        "location": "7->14",
                         "children": [],
                         "properties": {
                             "value": "dkjfkdk",
@@ -422,7 +422,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x15->1x16/14->15",
+                        "location": "14->15",
                         "children": []
                     }
                 ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockStatementOpeningWithoutId-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockStatementOpeningWithoutId-output.json
@@ -1,16 +1,16 @@
 [
     {
         "type": "at-html:opening",
-        "location": "1x1->1x3/0->2",
+        "location": "0->2",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": []
             }
         ],
@@ -22,16 +22,16 @@
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -39,7 +39,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x3->1x11/2->10",
+                "location": "2->10",
                 "children": [],
                 "properties": {
                     "value": "jksbhkdl"
@@ -47,7 +47,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x11->1x12/10->11",
+                "location": "10->11",
                 "children": []
             }
         ],
@@ -59,16 +59,16 @@
     },
     {
         "type": "at-html:opening",
-        "location": "1x1->1x4/0->3",
+        "location": "0->3",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -76,7 +76,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x3->1x4/2->3",
+                "location": "2->3",
                 "children": []
             }
         ],

--- a/test/app/node_modules/modes/at-html/parser/index/blockWidget-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/blockWidget-output.json
@@ -1,36 +1,36 @@
 [
     {
         "type": "at-html:block-widget",
-        "location": "1x1->2x8/0->32",
+        "location": "0->32",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x14/0->13",
+                "location": "0->13",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-widget-id",
-                        "location": "1x2->1x6/1->5",
+                        "location": "1->5",
                         "children": [
                             {
                                 "type": "at-html:at-widget-library",
-                                "location": "1x3->1x4/2->3",
+                                "location": "2->3",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-widget-name",
-                                "location": "1x5->1x6/4->5",
+                                "location": "4->5",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x6->1x7/5->6",
+                        "location": "5->6",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -38,7 +38,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x7->1x13/6->12",
+                        "location": "6->12",
                         "children": [],
                         "properties": {
                             "value": "djbldf"
@@ -46,50 +46,50 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x13->1x14/12->13",
+                        "location": "12->13",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:block-statement-content",
-                "location": "1x14->2x1/13->25",
+                "location": "13->25",
                 "children": [
                     {
                         "type": "at-html:text",
-                        "location": "1x14->2x1/13->25",
+                        "location": "13->25",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:closing",
-                "location": "2x1->2x33/25->32",
+                "location": "25->32",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "2x1->2x28/25->27",
+                        "location": "25->27",
                         "children": []
                     },
                     {
                         "type": "at-html:at-widget-id",
-                        "location": "2x3->2x32/27->31",
+                        "location": "27->31",
                         "children": [
                             {
                                 "type": "at-html:at-widget-library",
-                                "location": "2x4->2x30/28->29",
+                                "location": "28->29",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-widget-name",
-                                "location": "2x6->2x32/30->31",
+                                "location": "30->31",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "2x7->2x33/31->32",
+                        "location": "31->32",
                         "children": []
                     }
                 ]
@@ -98,36 +98,36 @@
     },
     {
         "type": "at-html:block-widget",
-        "location": "1x1->4x8/0->52",
+        "location": "0->52",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x14/0->13",
+                "location": "0->13",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-widget-id",
-                        "location": "1x2->1x6/1->5",
+                        "location": "1->5",
                         "children": [
                             {
                                 "type": "at-html:at-widget-library",
-                                "location": "1x3->1x4/2->3",
+                                "location": "2->3",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-widget-name",
-                                "location": "1x5->1x6/4->5",
+                                "location": "4->5",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x6->1x7/5->6",
+                        "location": "5->6",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -135,7 +135,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x7->1x13/6->12",
+                        "location": "6->12",
                         "children": [],
                         "properties": {
                             "value": "djbldf"
@@ -143,7 +143,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x13->1x14/12->13",
+                        "location": "12->13",
                         "children": []
                     }
                 ],
@@ -155,25 +155,25 @@
             },
             {
                 "type": "at-html:block-statement-content",
-                "location": "1x14->4x1/13->45",
+                "location": "13->45",
                 "children": [
                     {
                         "type": "at-html:text",
-                        "location": "1x14->2x1/13->21",
+                        "location": "13->21",
                         "children": []
                     },
                     {
                         "type": "at-html:expression",
-                        "location": "2x1->2x40/21->39",
+                        "location": "21->39",
                         "children": [
                             {
                                 "type": "at-html:opening",
-                                "location": "2x1->2x24/21->23",
+                                "location": "21->23",
                                 "children": []
                             },
                             {
                                 "type": "at-html:param",
-                                "location": "2x3->2x39/23->38",
+                                "location": "23->38",
                                 "children": [],
                                 "properties": {
                                     "value": "dsasdnklfdfnjsd"
@@ -181,14 +181,14 @@
                             },
                             {
                                 "type": "at-html:closing",
-                                "location": "2x18->2x40/38->39",
+                                "location": "38->39",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:eols",
-                        "location": "2x19->3x1/39->40",
+                        "location": "39->40",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -196,39 +196,39 @@
                     },
                     {
                         "type": "at-html:text",
-                        "location": "3x1->4x1/40->45",
+                        "location": "40->45",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:closing",
-                "location": "4x1->4x53/45->52",
+                "location": "45->52",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "4x1->4x48/45->47",
+                        "location": "45->47",
                         "children": []
                     },
                     {
                         "type": "at-html:at-widget-id",
-                        "location": "4x3->4x52/47->51",
+                        "location": "47->51",
                         "children": [
                             {
                                 "type": "at-html:at-widget-library",
-                                "location": "4x4->4x50/48->49",
+                                "location": "48->49",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-widget-name",
-                                "location": "4x6->4x52/50->51",
+                                "location": "50->51",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "4x7->4x53/51->52",
+                        "location": "51->52",
                         "children": []
                     }
                 ],
@@ -242,36 +242,36 @@
     },
     {
         "type": "at-html:block-widget",
-        "location": "1x1->1x19/0->18",
+        "location": "0->18",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x14/0->13",
+                "location": "0->13",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x1->1x2/0->1",
+                        "location": "0->1",
                         "children": []
                     },
                     {
                         "type": "at-html:at-widget-id",
-                        "location": "1x2->1x6/1->5",
+                        "location": "1->5",
                         "children": [
                             {
                                 "type": "at-html:at-widget-library",
-                                "location": "1x3->1x4/2->3",
+                                "location": "2->3",
                                 "children": []
                             },
                             {
                                 "type": "at-html:at-widget-name",
-                                "location": "1x5->1x6/4->5",
+                                "location": "4->5",
                                 "children": []
                             }
                         ]
                     },
                     {
                         "type": "at-html:spaces",
-                        "location": "1x6->1x7/5->6",
+                        "location": "5->6",
                         "children": [],
                         "properties": {
                             "size": 1
@@ -279,7 +279,7 @@
                     },
                     {
                         "type": "at-html:param",
-                        "location": "1x7->1x13/6->12",
+                        "location": "6->12",
                         "children": [],
                         "properties": {
                             "value": "djbldf"
@@ -287,7 +287,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x13->1x14/12->13",
+                        "location": "12->13",
                         "children": []
                     }
                 ],
@@ -299,20 +299,20 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x14->1x19/13->18",
+                "location": "13->18",
                 "children": [
                     {
                         "type": "at-html:opening",
-                        "location": "1x14->1x16/13->15",
+                        "location": "13->15",
                         "children": []
                     },
                     {
                         "type": "at-html:at-widget-id",
-                        "location": "1x16->1x18/15->17",
+                        "location": "15->17",
                         "children": [
                             {
                                 "type": "at-html:at-widget-library",
-                                "location": "1x17->1x18/16->17",
+                                "location": "16->17",
                                 "children": []
                             }
                         ],
@@ -324,7 +324,7 @@
                     },
                     {
                         "type": "at-html:closing",
-                        "location": "1x18->1x19/17->18",
+                        "location": "17->18",
                         "children": []
                     }
                 ],

--- a/test/app/node_modules/modes/at-html/parser/index/cdata-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/cdata-output.json
@@ -1,24 +1,24 @@
 {
     "type": "at-html:block-statement",
-    "location": "1x1->5x9/0->73",
+    "location": "0->73",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x22/0->21",
+            "location": "0->21",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x2/0->1",
+                    "location": "0->1",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "1x2->1x7/1->6",
+                    "location": "1->6",
                     "children": []
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "1x7->1x8/6->7",
+                    "location": "6->7",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -26,7 +26,7 @@
                 },
                 {
                     "type": "at-html:param",
-                    "location": "1x8->1x21/7->20",
+                    "location": "7->20",
                     "children": [],
                     "properties": {
                         "value": "djsdkfsdjksdd",
@@ -37,33 +37,33 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x21->1x22/20->21",
+                    "location": "20->21",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:block-statement-content",
-            "location": "1x22->5x1/21->65",
+            "location": "21->65",
             "children": []
         },
         {
             "type": "at-html:closing",
-            "location": "5x1->5x9/65->73",
+            "location": "65->73",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "5x1->5x3/65->67",
+                    "location": "65->67",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "5x3->5x8/67->72",
+                    "location": "67->72",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "5x8->5x9/72->73",
+                    "location": "72->73",
                     "children": []
                 }
             ]

--- a/test/app/node_modules/modes/at-html/parser/index/cdataOpening-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/cdataOpening-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:opening",
-    "location": "1x1->1x24/0->23",
+    "location": "0->23",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "at-html:at-id",
-            "location": "1x2->1x7/1->6",
+            "location": "1->6",
             "children": []
         },
         {
             "type": "at-html:spaces",
-            "location": "1x7->1x8/6->7",
+            "location": "6->7",
             "children": [],
             "properties": {
                 "size": 1
@@ -22,7 +22,7 @@
         },
         {
             "type": "at-html:param",
-            "location": "1x8->1x23/7->22",
+            "location": "7->22",
             "children": [],
             "properties": {
                 "value": "fdsdbflfjldjkfd",
@@ -33,7 +33,7 @@
         },
         {
             "type": "at-html:closing",
-            "location": "1x23->1x24/22->23",
+            "location": "22->23",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/doubleQuoteString-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/doubleQuoteString-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:string",
-    "location": "1x1->1x48/0->47",
+    "location": "0->47",
     "children": [
         {
             "type": "at-html:quotes.double",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "at-html:doubleQuoteString.content",
-            "location": "1x2->1x47/1->46",
+            "location": "1->46",
             "children": []
         },
         {
             "type": "at-html:quotes.double",
-            "location": "1x47->1x48/46->47",
+            "location": "46->47",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/eols-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/eols-output.json
@@ -1,6 +1,6 @@
 {
     "type": "at-html:eols",
-    "location": "1x1->9x1/0->16",
+    "location": "0->16",
     "children": [],
     "properties": {
         "size": 8

--- a/test/app/node_modules/modes/at-html/parser/index/expressionOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/expressionOne-output.json
@@ -1,32 +1,32 @@
 [
     {
         "type": "at-html:expression",
-        "location": "1x1->1x4/0->3",
+        "location": "0->3",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x3->1x4/2->3",
+                "location": "2->3",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:expression",
-        "location": "1x1->1x14/0->13",
+        "location": "0->13",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:param",
-                "location": "1x3->1x13/2->12",
+                "location": "2->12",
                 "children": [],
                 "properties": {
                     "value": "data.title"
@@ -34,23 +34,23 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x13->1x14/12->13",
+                "location": "12->13",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:expression",
-        "location": "1x1->5x2/0->25",
+        "location": "0->25",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:eols",
-                "location": "1x3->2x1/2->3",
+                "location": "2->3",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -58,7 +58,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "2x1->2x5/3->4",
+                "location": "3->4",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -66,7 +66,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "2x2->4x4/4->23",
+                "location": "4->23",
                 "children": [],
                 "properties": {
                     "value": "{\t\t\nhndbshbsj({\n})}"
@@ -74,7 +74,7 @@
             },
             {
                 "type": "at-html:eols",
-                "location": "4x4->5x1/23->24",
+                "location": "23->24",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -82,23 +82,23 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "5x1->5x26/24->25",
+                "location": "24->25",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:expression",
-        "location": "1x1->1x34/0->33",
+        "location": "0->33",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:param",
-                "location": "1x3->1x33/2->32",
+                "location": "2->32",
                 "children": [],
                 "properties": {
                     "value": "(function () {return \"aaa\"})()"
@@ -106,18 +106,18 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x33->1x34/32->33",
+                "location": "32->33",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:expression",
-        "location": "1x1->1x3/0->2",
+        "location": "0->2",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             }
         ],
@@ -129,16 +129,16 @@
     },
     {
         "type": "at-html:expression",
-        "location": "1x1->1x13/0->12",
+        "location": "0->12",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:param",
-                "location": "1x3->1x13/2->12",
+                "location": "2->12",
                 "children": [],
                 "properties": {
                     "value": "data.title"
@@ -153,16 +153,16 @@
     },
     {
         "type": "at-html:expression",
-        "location": "1x1->5x1/0->24",
+        "location": "0->24",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:eols",
-                "location": "1x3->2x1/2->3",
+                "location": "2->3",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -170,7 +170,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "2x1->2x5/3->4",
+                "location": "3->4",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -178,7 +178,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "2x2->4x4/4->23",
+                "location": "4->23",
                 "children": [],
                 "properties": {
                     "value": "{\t\t\nhndbshbsj({\n})}"
@@ -186,7 +186,7 @@
             },
             {
                 "type": "at-html:eols",
-                "location": "4x4->5x1/23->24",
+                "location": "23->24",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -201,16 +201,16 @@
     },
     {
         "type": "at-html:expression",
-        "location": "1x1->1x33/0->32",
+        "location": "0->32",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x3/0->2",
+                "location": "0->2",
                 "children": []
             },
             {
                 "type": "at-html:param",
-                "location": "1x3->1x33/2->32",
+                "location": "2->32",
                 "children": [],
                 "properties": {
                     "value": "(function () {return \"aaa\"})()"

--- a/test/app/node_modules/modes/at-html/parser/index/genericParam-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/genericParam-output.json
@@ -2,7 +2,7 @@
     [
         {
             "type": "at-html:spaces",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": [],
             "properties": {
                 "size": 1
@@ -10,7 +10,7 @@
         },
         {
             "type": "at-html:param",
-            "location": "1x2->2x32/1->50",
+            "location": "1->50",
             "children": [],
             "properties": {
                 "value": "djhvfjksdjs {} {\t\n{}djhfjksd fdhnkd juldjjdlb \\}}"
@@ -18,7 +18,7 @@
         },
         {
             "type": "at-html:spaces",
-            "location": "2x32->2x55/50->54",
+            "location": "50->54",
             "children": [],
             "properties": {
                 "size": 4
@@ -26,7 +26,7 @@
         },
         {
             "type": "at-html:tabs",
-            "location": "2x36->2x56/54->55",
+            "location": "54->55",
             "children": [],
             "properties": {
                 "size": 1
@@ -34,7 +34,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "2x37->3x1/55->56",
+            "location": "55->56",
             "children": [],
             "properties": {
                 "size": 1
@@ -44,7 +44,7 @@
     [
         {
             "type": "at-html:param",
-            "location": "1x1->2x18/0->27",
+            "location": "0->27",
             "children": [],
             "properties": {
                 "value": "{{}     \t\n{ } cjnckdl {{}}}"

--- a/test/app/node_modules/modes/at-html/parser/index/htmlCdata-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/htmlCdata-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:html-cdata",
-    "location": "1x1->9x4/0->88",
+    "location": "0->88",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x10/0->9",
+            "location": "0->9",
             "children": []
         },
         {
             "type": "at-html:content",
-            "location": "1x10->9x1/9->85",
+            "location": "9->85",
             "children": []
         },
         {
             "type": "at-html:closing",
-            "location": "9x1->9x89/85->88",
+            "location": "85->88",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/htmlComment-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/htmlComment-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:html-comment",
-    "location": "1x1->12x4/0->97",
+    "location": "0->97",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x5/0->4",
+            "location": "0->4",
             "children": []
         },
         {
             "type": "at-html:content",
-            "location": "1x5->12x1/4->94",
+            "location": "4->94",
             "children": []
         },
         {
             "type": "at-html:closing",
-            "location": "12x1->12x98/94->97",
+            "location": "94->97",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/id-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/id-output.json
@@ -1,17 +1,17 @@
 [
     {
         "type": "at-html:at-id",
-        "location": "1x1->1x19/0->18",
+        "location": "0->18",
         "children": []
     },
     {
         "type": "at-html:at-id",
-        "location": "1x1->1x15/0->14",
+        "location": "0->14",
         "children": []
     },
     {
         "type": "at-html:at-id",
-        "location": "1x1->1x4/0->3",
+        "location": "0->3",
         "children": []
     }
 ]

--- a/test/app/node_modules/modes/at-html/parser/index/inlineHtmlTagOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/inlineHtmlTagOne-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:inline-html-element",
-    "location": "1x1->1x54/0->53",
+    "location": "0->53",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "at-html:html-id",
-            "location": "1x2->1x3/1->2",
+            "location": "1->2",
             "children": []
         },
         {
             "type": "at-html:spaces",
-            "location": "1x3->1x4/2->3",
+            "location": "2->3",
             "children": [],
             "properties": {
                 "size": 1
@@ -22,30 +22,30 @@
         },
         {
             "type": "at-html:text",
-            "location": "1x4->1x28/3->27",
+            "location": "3->27",
             "children": []
         },
         {
             "type": "at-html:block-statement",
-            "location": "1x28->1x49/27->48",
+            "location": "27->48",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x28->1x38/27->37",
+                    "location": "27->37",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x28->1x29/27->28",
+                            "location": "27->28",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "1x29->1x31/28->30",
+                            "location": "28->30",
                             "children": []
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "1x31->1x32/30->31",
+                            "location": "30->31",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -53,7 +53,7 @@
                         },
                         {
                             "type": "at-html:param",
-                            "location": "1x32->1x37/31->36",
+                            "location": "31->36",
                             "children": [],
                             "properties": {
                                 "value": "a = 1"
@@ -61,7 +61,7 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x37->1x38/36->37",
+                            "location": "36->37",
                             "children": []
                         }
                     ],
@@ -74,32 +74,32 @@
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "1x38->1x44/37->43",
+                    "location": "37->43",
                     "children": [
                         {
                             "type": "at-html:text",
-                            "location": "1x38->1x44/37->43",
+                            "location": "37->43",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x44->1x49/43->48",
+                    "location": "43->48",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x44->1x46/43->45",
+                            "location": "43->45",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "1x46->1x48/45->47",
+                            "location": "45->47",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x48->1x49/47->48",
+                            "location": "47->48",
                             "children": []
                         }
                     ]
@@ -108,12 +108,12 @@
         },
         {
             "type": "at-html:text",
-            "location": "1x49->1x52/48->51",
+            "location": "48->51",
             "children": []
         },
         {
             "type": "at-html:closing",
-            "location": "1x52->1x54/51->53",
+            "location": "51->53",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/inlineHtmlTagThree-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/inlineHtmlTagThree-output.json
@@ -1,15 +1,15 @@
 {
     "type": "at-html:inline-html-element",
-    "location": "1x1->1x49/0->48",
+    "location": "0->48",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "at-html:spaces",
-            "location": "1x2->1x3/1->2",
+            "location": "1->2",
             "children": [],
             "properties": {
                 "size": 1
@@ -17,30 +17,30 @@
         },
         {
             "type": "at-html:text",
-            "location": "1x3->1x14/2->13",
+            "location": "2->13",
             "children": []
         },
         {
             "type": "at-html:block-statement",
-            "location": "1x14->1x47/13->46",
+            "location": "13->46",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x14->1x23/13->22",
+                    "location": "13->22",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x14->1x15/13->14",
+                            "location": "13->14",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "1x15->1x17/14->16",
+                            "location": "14->16",
                             "children": []
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "1x17->1x18/16->17",
+                            "location": "16->17",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -48,7 +48,7 @@
                         },
                         {
                             "type": "at-html:param",
-                            "location": "1x18->1x22/17->21",
+                            "location": "17->21",
                             "children": [],
                             "properties": {
                                 "value": "a==1"
@@ -56,7 +56,7 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x22->1x23/21->22",
+                            "location": "21->22",
                             "children": []
                         }
                     ],
@@ -69,30 +69,30 @@
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "1x23->1x42/22->41",
+                    "location": "22->41",
                     "children": [
                         {
                             "type": "at-html:text",
-                            "location": "1x23->1x28/22->27",
+                            "location": "22->27",
                             "children": []
                         },
                         {
                             "type": "at-html:inline-statement",
-                            "location": "1x28->1x35/27->34",
+                            "location": "27->34",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "1x28->1x29/27->28",
+                                    "location": "27->28",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:at-id",
-                                    "location": "1x29->1x33/28->32",
+                                    "location": "28->32",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "1x33->1x35/32->34",
+                                    "location": "32->34",
                                     "children": []
                                 }
                             ],
@@ -104,28 +104,28 @@
                         },
                         {
                             "type": "at-html:text",
-                            "location": "1x35->1x42/34->41",
+                            "location": "34->41",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x42->1x47/41->46",
+                    "location": "41->46",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x42->1x44/41->43",
+                            "location": "41->43",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "1x44->1x46/43->45",
+                            "location": "43->45",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x46->1x47/45->46",
+                            "location": "45->46",
                             "children": []
                         }
                     ]
@@ -134,7 +134,7 @@
         },
         {
             "type": "at-html:closing",
-            "location": "1x47->1x49/46->48",
+            "location": "46->48",
             "children": []
         }
     ],

--- a/test/app/node_modules/modes/at-html/parser/index/inlineHtmlTagTwo-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/inlineHtmlTagTwo-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:inline-html-element",
-    "location": "1x1->18x3/0->96",
+    "location": "0->96",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "at-html:html-id",
-            "location": "1x2->1x3/1->2",
+            "location": "1->2",
             "children": []
         },
         {
             "type": "at-html:eols",
-            "location": "1x3->3x1/2->6",
+            "location": "2->6",
             "children": [],
             "properties": {
                 "size": 2
@@ -22,28 +22,28 @@
         },
         {
             "type": "at-html:multi-line-comment",
-            "location": "3x1->4x3/6->22",
+            "location": "6->22",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "3x1->3x7/6->8",
+                    "location": "6->8",
                     "children": []
                 },
                 {
                     "type": "at-html:content",
-                    "location": "3x3->4x1/8->20",
+                    "location": "8->20",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "4x1->4x21/20->22",
+                    "location": "20->22",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "4x3->6x1/22->26",
+            "location": "22->26",
             "children": [],
             "properties": {
                 "size": 2
@@ -51,23 +51,23 @@
         },
         {
             "type": "at-html:single-line-comment",
-            "location": "6x1->6x37/26->38",
+            "location": "26->38",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "6x1->6x27/26->28",
+                    "location": "26->28",
                     "children": []
                 },
                 {
                     "type": "at-html:content",
-                    "location": "6x3->6x37/28->38",
+                    "location": "28->38",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "6x13->8x1/38->42",
+            "location": "38->42",
             "children": [],
             "properties": {
                 "size": 2
@@ -75,21 +75,21 @@
         },
         {
             "type": "at-html:inline-statement",
-            "location": "8x1->12x4/42->63",
+            "location": "42->63",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "8x1->8x42/42->43",
+                    "location": "42->43",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "8x2->8x49/43->50",
+                    "location": "43->50",
                     "children": []
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "8x9->8x10/50->51",
+                    "location": "50->51",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -97,7 +97,7 @@
                 },
                 {
                     "type": "at-html:param",
-                    "location": "8x10->12x2/51->61",
+                    "location": "51->61",
                     "children": [],
                     "properties": {
                         "value": "{\r\n\r\n\r\n\r\n}"
@@ -105,14 +105,14 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "12x2->12x62/61->63",
+                    "location": "61->63",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "12x4->14x1/63->67",
+            "location": "63->67",
             "children": [],
             "properties": {
                 "size": 2
@@ -120,21 +120,21 @@
         },
         {
             "type": "at-html:inline-statement",
-            "location": "14x1->14x78/67->79",
+            "location": "67->79",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "14x1->14x67/67->68",
+                    "location": "67->68",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "14x2->14x70/68->71",
+                    "location": "68->71",
                     "children": []
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "14x5->14x6/71->72",
+                    "location": "71->72",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -142,7 +142,7 @@
                 },
                 {
                     "type": "at-html:param",
-                    "location": "14x6->14x11/72->77",
+                    "location": "72->77",
                     "children": [],
                     "properties": {
                         "value": "i = 0"
@@ -150,14 +150,14 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "14x11->14x78/77->79",
+                    "location": "77->79",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "14x13->16x1/79->83",
+            "location": "79->83",
             "children": [],
             "properties": {
                 "size": 2
@@ -165,16 +165,16 @@
         },
         {
             "type": "at-html:expression",
-            "location": "16x1->16x89/83->90",
+            "location": "83->90",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "16x1->16x84/83->85",
+                    "location": "83->85",
                     "children": []
                 },
                 {
                     "type": "at-html:param",
-                    "location": "16x3->16x88/85->89",
+                    "location": "85->89",
                     "children": [],
                     "properties": {
                         "value": "ahsg"
@@ -182,14 +182,14 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "16x7->16x89/89->90",
+                    "location": "89->90",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "16x8->18x1/90->94",
+            "location": "90->94",
             "children": [],
             "properties": {
                 "size": 2
@@ -197,7 +197,7 @@
         },
         {
             "type": "at-html:closing",
-            "location": "18x1->18x97/94->96",
+            "location": "94->96",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/inlineStatementMissingId-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/inlineStatementMissingId-output.json
@@ -1,16 +1,16 @@
 [
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x4/0->3",
+        "location": "0->3",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x2->1x4/1->3",
+                "location": "1->3",
                 "children": []
             }
         ],
@@ -22,16 +22,16 @@
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -39,7 +39,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x3->1x10/2->9",
+                "location": "2->9",
                 "children": [],
                 "properties": {
                     "value": "hjvfjhd"
@@ -47,7 +47,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x10->1x12/9->11",
+                "location": "9->11",
                 "children": []
             }
         ],

--- a/test/app/node_modules/modes/at-html/parser/index/inlineStatementOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/inlineStatementOne-output.json
@@ -1,21 +1,21 @@
 [
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->3x5/0->32",
+        "location": "0->32",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x9/1->8",
+                "location": "1->8",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x9->1x10/8->9",
+                "location": "8->9",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -23,7 +23,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x10->3x2/9->29",
+                "location": "9->29",
                 "children": [],
                 "properties": {
                     "value": "{\n\tid : \"whatever\"\n}"
@@ -31,7 +31,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "3x2->3x23/29->30",
+                "location": "29->30",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -39,28 +39,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "3x3->3x33/30->32",
+                "location": "30->32",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x52/0->51",
+        "location": "0->51",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x4/1->3",
+                "location": "1->3",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x4->1x6/3->5",
+                "location": "3->5",
                 "children": [],
                 "properties": {
                     "size": 2
@@ -68,7 +68,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x6->1x49/5->48",
+                "location": "5->48",
                 "children": [],
                 "properties": {
                     "value": "click { fn : method, scope : this, args:{}}"
@@ -76,7 +76,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x49->1x50/48->49",
+                "location": "48->49",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -84,28 +84,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x50->1x52/49->51",
+                "location": "49->51",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->2x42/0->51",
+        "location": "0->51",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x8/1->7",
+                "location": "1->7",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x8->1x10/7->9",
+                "location": "7->9",
                 "children": [],
                 "properties": {
                     "size": 2
@@ -113,7 +113,7 @@
             },
             {
                 "type": "at-html:eols",
-                "location": "1x10->2x1/9->10",
+                "location": "9->10",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -121,7 +121,7 @@
             },
             {
                 "type": "at-html:tabs",
-                "location": "2x1->2x5/10->11",
+                "location": "10->11",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -129,7 +129,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "2x2->2x42/11->48",
+                "location": "11->48",
                 "children": [],
                 "properties": {
                     "value": "{ fn : method, scope : this, args:{}}"
@@ -137,7 +137,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "2x39->2x43/48->49",
+                "location": "48->49",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -145,7 +145,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "2x40->2x52/49->51",
+                "location": "49->51",
                 "children": []
             }
         ],
@@ -157,21 +157,21 @@
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x14/0->13",
+        "location": "0->13",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x7/1->6",
+                "location": "1->6",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x7->1x8/6->7",
+                "location": "6->7",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -179,7 +179,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x8->1x11/7->10",
+                "location": "7->10",
                 "children": [],
                 "properties": {
                     "value": "aaa",
@@ -190,7 +190,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x11->1x12/10->11",
+                "location": "10->11",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -198,7 +198,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x12->1x14/11->13",
+                "location": "11->13",
                 "children": []
             }
         ],
@@ -210,21 +210,21 @@
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x14/0->13",
+        "location": "0->13",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x5/1->4",
+                "location": "1->4",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x5->1x6/4->5",
+                "location": "4->5",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -232,7 +232,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x6->1x11/5->10",
+                "location": "5->10",
                 "children": [],
                 "properties": {
                     "value": "v = 5"
@@ -240,7 +240,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x11->1x12/10->11",
+                "location": "10->11",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -248,28 +248,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x12->1x14/11->13",
+                "location": "11->13",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x5/1->4",
+                "location": "1->4",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x5->1x6/4->5",
+                "location": "4->5",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -277,7 +277,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x6->1x9/5->8",
+                "location": "5->8",
                 "children": [],
                 "properties": {
                     "value": "v 5",
@@ -288,7 +288,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x9->1x10/8->9",
+                "location": "8->9",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -296,28 +296,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x10->1x12/9->11",
+                "location": "9->11",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x15/0->14",
+        "location": "0->14",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x5/1->4",
+                "location": "1->4",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x5->1x6/4->5",
+                "location": "4->5",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -325,7 +325,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x6->1x12/5->11",
+                "location": "5->11",
                 "children": [],
                 "properties": {
                     "value": "v = 10"
@@ -333,7 +333,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x12->1x13/11->12",
+                "location": "11->12",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -341,28 +341,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x13->1x15/12->14",
+                "location": "12->14",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x7/0->6",
+        "location": "0->6",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x5/1->4",
+                "location": "1->4",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x5->1x7/4->6",
+                "location": "4->6",
                 "children": []
             }
         ],

--- a/test/app/node_modules/modes/at-html/parser/index/inlineStatementTwo-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/inlineStatementTwo-output.json
@@ -1,21 +1,21 @@
 [
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x23/0->22",
+        "location": "0->22",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x14/1->13",
+                "location": "1->13",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x14->1x15/13->14",
+                "location": "13->14",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -23,7 +23,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x15->1x20/14->19",
+                "location": "14->19",
                 "children": [],
                 "properties": {
                     "value": "v = 1"
@@ -31,7 +31,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x20->1x21/19->20",
+                "location": "19->20",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -39,28 +39,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x21->1x23/20->22",
+                "location": "20->22",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x22/0->21",
+        "location": "0->21",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x15/1->14",
+                "location": "1->14",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x15->1x16/14->15",
+                "location": "14->15",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -68,7 +68,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x16->1x19/15->18",
+                "location": "15->18",
                 "children": [],
                 "properties": {
                     "value": "= 1"
@@ -76,7 +76,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x19->1x20/18->19",
+                "location": "18->19",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -84,7 +84,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x20->1x22/19->21",
+                "location": "19->21",
                 "children": []
             }
         ],
@@ -96,21 +96,21 @@
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x37/0->36",
+        "location": "0->36",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x8/1->7",
+                "location": "1->7",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x8->1x9/7->8",
+                "location": "7->8",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -118,7 +118,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x9->1x35/8->34",
+                "location": "8->34",
                 "children": [],
                 "properties": {
                     "value": "data.passengers.length < 5"
@@ -126,49 +126,49 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x35->1x37/34->36",
+                "location": "34->36",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x10/0->9",
+        "location": "0->9",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x8/1->7",
+                "location": "1->7",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "1x8->1x10/7->9",
+                "location": "7->9",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x35/0->34",
+        "location": "0->34",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x6->1x7/5->6",
+                "location": "5->6",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -176,7 +176,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x7->1x33/6->32",
+                "location": "6->32",
                 "children": [],
                 "properties": {
                     "value": "data.passengers.length < 5",
@@ -187,28 +187,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x33->1x35/32->34",
+                "location": "32->34",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x32/0->31",
+        "location": "0->31",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x6->1x7/5->6",
+                "location": "5->6",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -216,7 +216,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x7->1x30/6->29",
+                "location": "6->29",
                 "children": [],
                 "properties": {
                     "value": "myMacro(param1, param2)"
@@ -224,28 +224,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x30->1x32/29->31",
+                "location": "29->31",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x16/0->15",
+        "location": "0->15",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x6->1x7/5->6",
+                "location": "5->6",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -253,7 +253,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x7->1x14/6->13",
+                "location": "6->13",
                 "children": [],
                 "properties": {
                     "value": "myMacro",
@@ -264,28 +264,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x14->1x16/13->15",
+                "location": "13->15",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x13/0->12",
+        "location": "0->12",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x4/1->3",
+                "location": "1->3",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x4->1x5/3->4",
+                "location": "3->4",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -293,7 +293,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x5->1x11/4->10",
+                "location": "4->10",
                 "children": [],
                 "properties": {
                     "value": "\"test\""
@@ -301,28 +301,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x11->1x13/10->12",
+                "location": "10->12",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x16/0->15",
+        "location": "0->15",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x4/1->3",
+                "location": "1->3",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x4->1x5/3->4",
+                "location": "3->4",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -330,7 +330,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x5->1x14/4->13",
+                "location": "4->13",
                 "children": [],
                 "properties": {
                     "value": "data.test"
@@ -338,28 +338,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x14->1x16/13->15",
+                "location": "13->15",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x37/0->36",
+        "location": "0->36",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x12/1->11",
+                "location": "1->11",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x12->1x13/11->12",
+                "location": "11->12",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -367,7 +367,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x13->1x35/12->34",
+                "location": "12->34",
                 "children": [],
                 "properties": {
                     "value": "viewName on arrayOrMap"
@@ -375,28 +375,28 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x35->1x37/34->36",
+                "location": "34->36",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-statement",
-        "location": "1x1->1x36/0->35",
+        "location": "0->35",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-id",
-                "location": "1x2->1x12/1->11",
+                "location": "1->11",
                 "children": []
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x12->1x13/11->12",
+                "location": "11->12",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -404,7 +404,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x13->1x34/12->33",
+                "location": "12->33",
                 "children": [],
                 "properties": {
                     "value": "viewName onarrayOrMap",
@@ -415,7 +415,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "1x34->1x36/33->35",
+                "location": "33->35",
                 "children": []
             }
         ]

--- a/test/app/node_modules/modes/at-html/parser/index/inlineWidget-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/inlineWidget-output.json
@@ -1,32 +1,32 @@
 [
     {
         "type": "at-html:inline-widget",
-        "location": "1x1->5x3/0->45",
+        "location": "0->45",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-widget-id",
-                "location": "1x2->1x13/1->12",
+                "location": "1->12",
                 "children": [
                     {
                         "type": "at-html:at-widget-library",
-                        "location": "1x3->1x7/2->6",
+                        "location": "2->6",
                         "children": []
                     },
                     {
                         "type": "at-html:at-widget-name",
-                        "location": "1x8->1x13/7->12",
+                        "location": "7->12",
                         "children": []
                     }
                 ]
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x13->1x14/12->13",
+                "location": "12->13",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -34,7 +34,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x14->4x2/13->42",
+                "location": "13->42",
                 "children": [],
                 "properties": {
                     "value": "{\n\t\tfjhdbjf: \"dsdsdsdsdsd\"\n\n}"
@@ -42,7 +42,7 @@
             },
             {
                 "type": "at-html:eols",
-                "location": "4x2->5x1/42->43",
+                "location": "42->43",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -50,23 +50,23 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "5x1->5x46/43->45",
+                "location": "43->45",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-widget",
-        "location": "1x1->5x3/0->35",
+        "location": "0->35",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-widget-id",
-                "location": "1x2->1x3/1->2",
+                "location": "1->2",
                 "children": [],
                 "properties": {
                     "errors": [
@@ -77,7 +77,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x3->1x4/2->3",
+                "location": "2->3",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -85,7 +85,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x4->4x2/3->32",
+                "location": "3->32",
                 "children": [],
                 "properties": {
                     "value": "{\n\t\tfjhdbjf: \"dsdsdsdsdsd\"\n\n}"
@@ -93,7 +93,7 @@
             },
             {
                 "type": "at-html:eols",
-                "location": "4x2->5x1/32->33",
+                "location": "32->33",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -101,27 +101,27 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "5x1->5x36/33->35",
+                "location": "33->35",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:inline-widget",
-        "location": "1x1->5x3/0->39",
+        "location": "0->39",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "1x1->1x2/0->1",
+                "location": "0->1",
                 "children": []
             },
             {
                 "type": "at-html:at-widget-id",
-                "location": "1x2->1x7/1->6",
+                "location": "1->6",
                 "children": [
                     {
                         "type": "at-html:at-widget-library",
-                        "location": "1x3->1x7/2->6",
+                        "location": "2->6",
                         "children": []
                     }
                 ],
@@ -133,7 +133,7 @@
             },
             {
                 "type": "at-html:spaces",
-                "location": "1x7->1x8/6->7",
+                "location": "6->7",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -141,7 +141,7 @@
             },
             {
                 "type": "at-html:param",
-                "location": "1x8->4x2/7->36",
+                "location": "7->36",
                 "children": [],
                 "properties": {
                     "value": "{\n\t\tfjhdbjf: \"dsdsdsdsdsd\"\n\n}"
@@ -149,7 +149,7 @@
             },
             {
                 "type": "at-html:eols",
-                "location": "4x2->5x1/36->37",
+                "location": "36->37",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -157,7 +157,7 @@
             },
             {
                 "type": "at-html:closing",
-                "location": "5x1->5x40/37->39",
+                "location": "37->39",
                 "children": []
             }
         ]

--- a/test/app/node_modules/modes/at-html/parser/index/multiLineComment-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/multiLineComment-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:multi-line-comment",
-    "location": "1x1->7x30/0->77",
+    "location": "0->77",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x3/0->2",
+            "location": "0->2",
             "children": []
         },
         {
             "type": "at-html:content",
-            "location": "1x3->7x28/2->75",
+            "location": "2->75",
             "children": []
         },
         {
             "type": "at-html:closing",
-            "location": "7x28->7x78/75->77",
+            "location": "75->77",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/multiLineCommentError-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/multiLineCommentError-output.json
@@ -1,15 +1,15 @@
 {
     "type": "at-html:multi-line-comment",
-    "location": "1x1->7x28/0->75",
+    "location": "0->75",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x3/0->2",
+            "location": "0->2",
             "children": []
         },
         {
             "type": "at-html:content",
-            "location": "1x3->7x28/2->75",
+            "location": "2->75",
             "children": []
         }
     ],

--- a/test/app/node_modules/modes/at-html/parser/index/multiLineCommentNoContent-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/multiLineCommentNoContent-output.json
@@ -1,15 +1,15 @@
 {
     "type": "at-html:multi-line-comment",
-    "location": "1x1->1x5/0->4",
+    "location": "0->4",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x3/0->2",
+            "location": "0->2",
             "children": []
         },
         {
             "type": "at-html:closing",
-            "location": "1x3->1x5/2->4",
+            "location": "2->4",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/singleLineComment-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/singleLineComment-output.json
@@ -1,15 +1,15 @@
 {
     "type": "at-html:single-line-comment",
-    "location": "1x1->1x42/0->41",
+    "location": "0->41",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x3/0->2",
+            "location": "0->2",
             "children": []
         },
         {
             "type": "at-html:content",
-            "location": "1x3->1x42/2->41",
+            "location": "2->41",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/singleQuoteString-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/singleQuoteString-output.json
@@ -1,20 +1,20 @@
 {
     "type": "at-html:string",
-    "location": "1x1->1x66/0->65",
+    "location": "0->65",
     "children": [
         {
             "type": "at-html:quotes.single",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "at-html:singleQuoteString.content",
-            "location": "1x2->1x65/1->64",
+            "location": "1->64",
             "children": []
         },
         {
             "type": "at-html:quotes.single",
-            "location": "1x65->1x66/64->65",
+            "location": "64->65",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/at-html/parser/index/spaces-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/spaces-output.json
@@ -1,6 +1,6 @@
 {
     "type": "at-html:spaces",
-    "location": "1x1->1x9/0->8",
+    "location": "0->8",
     "children": [],
     "properties": {
         "size": 8

--- a/test/app/node_modules/modes/at-html/parser/index/spacesAndComments-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/spacesAndComments-output.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "at-html:tabs",
-        "location": "1x1->1x5/0->4",
+        "location": "0->4",
         "children": [],
         "properties": {
             "size": 4
@@ -9,7 +9,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "1x5->1x6/4->5",
+        "location": "4->5",
         "children": [],
         "properties": {
             "size": 1
@@ -17,7 +17,7 @@
     },
     {
         "type": "at-html:eols",
-        "location": "1x6->2x1/5->7",
+        "location": "5->7",
         "children": [],
         "properties": {
             "size": 1
@@ -25,28 +25,28 @@
     },
     {
         "type": "at-html:multi-line-comment",
-        "location": "2x1->4x5/7->22",
+        "location": "7->22",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "2x1->2x10/7->9",
+                "location": "7->9",
                 "children": []
             },
             {
                 "type": "at-html:content",
-                "location": "2x3->4x3/9->20",
+                "location": "9->20",
                 "children": []
             },
             {
                 "type": "at-html:closing",
-                "location": "4x3->4x23/20->22",
+                "location": "20->22",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:eols",
-        "location": "4x5->7x1/22->28",
+        "location": "22->28",
         "children": [],
         "properties": {
             "size": 3
@@ -54,7 +54,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "7x1->7x31/28->30",
+        "location": "28->30",
         "children": [],
         "properties": {
             "size": 2
@@ -62,23 +62,23 @@
     },
     {
         "type": "at-html:single-line-comment",
-        "location": "7x3->7x45/30->44",
+        "location": "30->44",
         "children": [
             {
                 "type": "at-html:opening",
-                "location": "7x3->7x33/30->32",
+                "location": "30->32",
                 "children": []
             },
             {
                 "type": "at-html:content",
-                "location": "7x5->7x45/32->44",
+                "location": "32->44",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:eols",
-        "location": "7x17->8x1/44->46",
+        "location": "44->46",
         "children": [],
         "properties": {
             "size": 1
@@ -86,7 +86,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "8x1->8x49/46->48",
+        "location": "46->48",
         "children": [],
         "properties": {
             "size": 2
@@ -94,7 +94,7 @@
     },
     {
         "type": "at-html:eols",
-        "location": "8x3->9x1/48->50",
+        "location": "48->50",
         "children": [],
         "properties": {
             "size": 1
@@ -102,7 +102,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "9x1->9x52/50->51",
+        "location": "50->51",
         "children": [],
         "properties": {
             "size": 1
@@ -110,7 +110,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "9x2->9x53/51->52",
+        "location": "51->52",
         "children": [],
         "properties": {
             "size": 1

--- a/test/app/node_modules/modes/at-html/parser/index/startEight-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startEight-output.json
@@ -1,24 +1,24 @@
 {
     "type": "at-html:root",
-    "location": "1x1->161x1/0->5964",
+    "location": "0->5964",
     "children": [
         {
             "type": "at-html:multi-line-comment",
-            "location": "1x1->14x4/0->606",
+            "location": "0->606",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x3/0->2",
+                    "location": "0->2",
                     "children": []
                 },
                 {
                     "type": "at-html:content",
-                    "location": "1x3->14x2/2->604",
+                    "location": "2->604",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "14x2->14x607/604->606",
+                    "location": "604->606",
                     "children": []
                 }
             ],
@@ -28,7 +28,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "14x4->16x1/606->610",
+            "location": "606->610",
             "children": [],
             "properties": {
                 "size": 2
@@ -36,23 +36,23 @@
         },
         {
             "type": "at-html:single-line-comment",
-            "location": "16x1->16x646/610->645",
+            "location": "610->645",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "16x1->16x613/610->612",
+                    "location": "610->612",
                     "children": []
                 },
                 {
                     "type": "at-html:content",
-                    "location": "16x3->16x646/612->645",
+                    "location": "612->645",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "16x36->17x1/645->647",
+            "location": "645->647",
             "children": [],
             "properties": {
                 "size": 1
@@ -60,25 +60,25 @@
         },
         {
             "type": "at-html:block-statement",
-            "location": "17x1->160x12/647->5962",
+            "location": "647->5962",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "17x1->23x3/647->828",
+                    "location": "647->828",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "17x1->17x649/647->648",
+                            "location": "647->648",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "17x2->17x657/648->656",
+                            "location": "648->656",
                             "children": []
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "17x10->17x658/656->657",
+                            "location": "656->657",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -86,7 +86,7 @@
                         },
                         {
                             "type": "at-html:param",
-                            "location": "17x11->23x2/657->827",
+                            "location": "657->827",
                             "children": [],
                             "properties": {
                                 "value": "{\r\n    $classpath:'aria.widgets.form.templates.TemplateMultiSelect',\r\n    $hasScript:true,\r\n    $res:{\r\n      footerRes : 'aria.resources.multiselect.FooterRes'\r\n    }\r\n}"
@@ -94,18 +94,18 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "23x2->23x829/827->828",
+                            "location": "827->828",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "23x3->160x1/828->5951",
+                    "location": "828->5951",
                     "children": [
                         {
                             "type": "at-html:eols",
-                            "location": "23x3->24x1/828->830",
+                            "location": "828->830",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -113,7 +113,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "24x1->24x835/830->834",
+                            "location": "830->834",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -121,25 +121,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "24x5->32x13/834->1169",
+                            "location": "834->1169",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "24x5->24x849/834->848",
+                                    "location": "834->848",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "24x5->24x836/834->835",
+                                            "location": "834->835",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "24x6->24x841/835->840",
+                                            "location": "835->840",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "24x11->24x842/840->841",
+                                            "location": "840->841",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -147,7 +147,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "24x12->24x848/841->847",
+                                            "location": "841->847",
                                             "children": [],
                                             "properties": {
                                                 "value": "main()"
@@ -155,18 +155,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "24x18->24x849/847->848",
+                                            "location": "847->848",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "24x19->32x5/848->1161",
+                                    "location": "848->1161",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "24x19->25x1/848->850",
+                                            "location": "848->850",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -174,7 +174,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "25x1->25x859/850->858",
+                                            "location": "850->858",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -182,23 +182,23 @@
                                         },
                                         {
                                             "type": "at-html:single-line-comment",
-                                            "location": "25x9->25x921/858->920",
+                                            "location": "858->920",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "25x9->25x861/858->860",
+                                                    "location": "858->860",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:content",
-                                                    "location": "25x11->25x921/860->920",
+                                                    "location": "860->920",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "25x71->26x1/920->922",
+                                            "location": "920->922",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -206,7 +206,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "26x1->26x931/922->930",
+                                            "location": "922->930",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -214,36 +214,36 @@
                                         },
                                         {
                                             "type": "at-html:block-widget",
-                                            "location": "26x9->31x21/930->1155",
+                                            "location": "930->1155",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "26x9->26x951/930->950",
+                                                    "location": "930->950",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "26x9->26x932/930->931",
+                                                            "location": "930->931",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-id",
-                                                            "location": "26x10->26x941/931->940",
+                                                            "location": "931->940",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:at-widget-library",
-                                                                    "location": "26x11->26x937/932->936",
+                                                                    "location": "932->936",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-widget-name",
-                                                                    "location": "26x16->26x941/937->940",
+                                                                    "location": "937->940",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "26x19->26x942/940->941",
+                                                            "location": "940->941",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -251,7 +251,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "26x20->26x950/941->949",
+                                                            "location": "941->949",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "data.cfg"
@@ -259,18 +259,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "26x28->26x951/949->950",
+                                                            "location": "949->950",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "26x29->31x9/950->1143",
+                                                    "location": "950->1143",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "26x29->27x1/950->952",
+                                                            "location": "950->952",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -278,7 +278,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "27x1->27x969/952->968",
+                                                            "location": "952->968",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 16
@@ -286,21 +286,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "27x17->27x1015/968->1014",
+                                                            "location": "968->1014",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "27x17->27x970/968->969",
+                                                                    "location": "968->969",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "27x18->27x977/969->976",
+                                                                    "location": "969->976",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "27x25->27x26/976->977",
+                                                                    "location": "976->977",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -308,7 +308,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "27x26->27x60/977->1011",
+                                                                    "location": "977->1011",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "{id: 'Items', macro: 'renderList'}"
@@ -316,7 +316,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "27x60->27x61/1011->1012",
+                                                                    "location": "1011->1012",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -324,14 +324,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "27x61->27x1015/1012->1014",
+                                                                    "location": "1012->1014",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "27x63->28x1/1014->1016",
+                                                            "location": "1014->1016",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -339,7 +339,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "28x1->28x1033/1016->1032",
+                                                            "location": "1016->1032",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 16
@@ -347,25 +347,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-statement",
-                                                            "location": "28x17->30x22/1032->1133",
+                                                            "location": "1032->1133",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "28x17->28x1073/1032->1072",
+                                                                    "location": "1032->1072",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "28x17->28x1034/1032->1033",
+                                                                            "location": "1032->1033",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "28x18->28x1036/1033->1035",
+                                                                            "location": "1033->1035",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "28x20->28x1037/1035->1036",
+                                                                            "location": "1035->1036",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -373,7 +373,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:param",
-                                                                            "location": "28x21->28x1072/1036->1071",
+                                                                            "location": "1036->1071",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "value": "(data.displayOptions.displayFooter)"
@@ -381,18 +381,18 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "28x56->28x1073/1071->1072",
+                                                                            "location": "1071->1072",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-statement-content",
-                                                                    "location": "28x57->30x17/1072->1128",
+                                                                    "location": "1072->1128",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "28x57->29x1/1072->1074",
+                                                                            "location": "1072->1074",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -400,7 +400,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "29x1->29x1095/1074->1094",
+                                                                            "location": "1074->1094",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 20
@@ -408,21 +408,21 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-statement",
-                                                                            "location": "29x21->29x1111/1094->1110",
+                                                                            "location": "1094->1110",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "29x21->29x1096/1094->1095",
+                                                                                    "location": "1094->1095",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-id",
-                                                                                    "location": "29x22->29x1100/1095->1099",
+                                                                                    "location": "1095->1099",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "29x26->29x27/1099->1100",
+                                                                                    "location": "1099->1100",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -430,7 +430,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "29x27->29x35/1100->1108",
+                                                                                    "location": "1100->1108",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "footer()"
@@ -438,14 +438,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "29x35->29x1111/1108->1110",
+                                                                                    "location": "1108->1110",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "29x37->30x1/1110->1112",
+                                                                            "location": "1110->1112",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -453,7 +453,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "30x1->30x1129/1112->1128",
+                                                                            "location": "1112->1128",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -463,21 +463,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "30x17->30x1134/1128->1133",
+                                                                    "location": "1128->1133",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "30x17->30x1131/1128->1130",
+                                                                            "location": "1128->1130",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "30x19->30x1133/1130->1132",
+                                                                            "location": "1130->1132",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "30x21->30x1134/1132->1133",
+                                                                            "location": "1132->1133",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -489,7 +489,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "30x22->31x1/1133->1135",
+                                                            "location": "1133->1135",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -497,7 +497,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "31x1->31x1144/1135->1143",
+                                                            "location": "1135->1143",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -507,32 +507,32 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "31x9->31x1156/1143->1155",
+                                                    "location": "1143->1155",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "31x9->31x1146/1143->1145",
+                                                            "location": "1143->1145",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-id",
-                                                            "location": "31x11->31x1155/1145->1154",
+                                                            "location": "1145->1154",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:at-widget-library",
-                                                                    "location": "31x12->31x1151/1146->1150",
+                                                                    "location": "1146->1150",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-widget-name",
-                                                                    "location": "31x17->31x1155/1151->1154",
+                                                                    "location": "1151->1154",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "31x20->31x1156/1154->1155",
+                                                            "location": "1154->1155",
                                                             "children": []
                                                         }
                                                     ]
@@ -544,7 +544,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "31x21->32x1/1155->1157",
+                                            "location": "1155->1157",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -552,7 +552,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "32x1->32x1162/1157->1161",
+                                            "location": "1157->1161",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -562,21 +562,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "32x5->32x1170/1161->1169",
+                                    "location": "1161->1169",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "32x5->32x1164/1161->1163",
+                                            "location": "1161->1163",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "32x7->32x1169/1163->1168",
+                                            "location": "1163->1168",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "32x12->32x1170/1168->1169",
+                                            "location": "1168->1169",
                                             "children": []
                                         }
                                     ]
@@ -588,7 +588,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "32x13->34x1/1169->1173",
+                            "location": "1169->1173",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -596,7 +596,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "34x1->34x1178/1173->1177",
+                            "location": "1173->1177",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -604,25 +604,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "34x5->85x13/1177->3607",
+                            "location": "1177->3607",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "34x5->34x1202/1177->1201",
+                                    "location": "1177->1201",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "34x5->34x1179/1177->1178",
+                                            "location": "1177->1178",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "34x6->34x1184/1178->1183",
+                                            "location": "1178->1183",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "34x11->34x1185/1183->1184",
+                                            "location": "1183->1184",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -630,7 +630,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "34x12->34x1201/1184->1200",
+                                            "location": "1184->1200",
                                             "children": [],
                                             "properties": {
                                                 "value": "renderList(item)"
@@ -638,18 +638,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "34x28->34x1202/1200->1201",
+                                            "location": "1200->1201",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "34x29->85x5/1201->3599",
+                                    "location": "1201->3599",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "34x29->35x1/1201->1203",
+                                            "location": "1201->1203",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -657,7 +657,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "35x1->35x1212/1203->1211",
+                                            "location": "1203->1211",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -665,25 +665,25 @@
                                         },
                                         {
                                             "type": "at-html:block-statement",
-                                            "location": "35x9->84x14/1211->3593",
+                                            "location": "1211->3593",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "35x9->35x1270/1211->1269",
+                                                    "location": "1211->1269",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "35x9->35x1213/1211->1212",
+                                                            "location": "1211->1212",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "35x10->35x1215/1212->1214",
+                                                            "location": "1212->1214",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "35x12->35x1216/1214->1215",
+                                                            "location": "1214->1215",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -691,7 +691,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "35x13->35x1269/1215->1268",
+                                                            "location": "1215->1268",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "(data.displayOptions.flowOrientation == 'horizontal')"
@@ -699,18 +699,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "35x66->35x1270/1268->1269",
+                                                            "location": "1268->1269",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "35x67->84x9/1269->3588",
+                                                    "location": "1269->3588",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "35x67->36x1/1269->1271",
+                                                            "location": "1269->1271",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -718,7 +718,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "36x1->36x1284/1271->1283",
+                                                            "location": "1271->1283",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -726,23 +726,23 @@
                                                         },
                                                         {
                                                             "type": "at-html:single-line-comment",
-                                                            "location": "36x13->36x1311/1283->1310",
+                                                            "location": "1283->1310",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "36x13->36x1286/1283->1285",
+                                                                    "location": "1283->1285",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:content",
-                                                                    "location": "36x15->36x1311/1285->1310",
+                                                                    "location": "1285->1310",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "36x40->37x1/1310->1312",
+                                                            "location": "1310->1312",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -750,7 +750,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "37x1->37x1325/1312->1324",
+                                                            "location": "1312->1324",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -758,36 +758,36 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-html-element",
-                                                            "location": "37x13->56x21/1324->2438",
+                                                            "location": "1324->2438",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "37x13->37x1332/1324->1331",
+                                                                    "location": "1324->1331",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "37x13->37x1326/1324->1325",
+                                                                            "location": "1324->1325",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "37x14->37x1331/1325->1330",
+                                                                            "location": "1325->1330",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "37x19->37x1332/1330->1331",
+                                                                            "location": "1330->1331",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-html-element-content",
-                                                                    "location": "37x20->56x13/1331->2430",
+                                                                    "location": "1331->2430",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "37x20->38x1/1331->1333",
+                                                                            "location": "1331->1333",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -795,7 +795,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "38x1->38x1346/1333->1345",
+                                                                            "location": "1333->1345",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -803,25 +803,25 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:block-statement",
-                                                                            "location": "38x13->55x23/1345->2416",
+                                                                            "location": "1345->2416",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "38x13->38x1382/1345->1381",
+                                                                                    "location": "1345->1381",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "38x13->38x1347/1345->1346",
+                                                                                            "location": "1345->1346",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "38x14->38x1354/1346->1353",
+                                                                                            "location": "1346->1353",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "38x21->38x1355/1353->1354",
+                                                                                            "location": "1353->1354",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -829,7 +829,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:param",
-                                                                                            "location": "38x22->38x1381/1354->1380",
+                                                                                            "location": "1354->1380",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "value": "item inView data.itemsView"
@@ -837,18 +837,18 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "38x48->38x1382/1380->1381",
+                                                                                            "location": "1380->1381",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:block-statement-content",
-                                                                                    "location": "38x49->55x13/1381->2406",
+                                                                                    "location": "1381->2406",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "38x49->39x1/1381->1383",
+                                                                                            "location": "1381->1383",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -856,7 +856,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "39x1->39x1400/1383->1399",
+                                                                                            "location": "1383->1399",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -864,25 +864,25 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:block-statement",
-                                                                                            "location": "39x17->41x22/1399->1491",
+                                                                                            "location": "1399->1491",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "39x17->39x1443/1399->1442",
+                                                                                                    "location": "1399->1442",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "39x17->39x1401/1399->1400",
+                                                                                                            "location": "1399->1400",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "39x18->39x1403/1400->1402",
+                                                                                                            "location": "1400->1402",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "39x20->39x1404/1402->1403",
+                                                                                                            "location": "1402->1403",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -890,7 +890,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:param",
-                                                                                                            "location": "39x21->39x1442/1403->1441",
+                                                                                                            "location": "1403->1441",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "value": "item_index % data.numberOfColumns == 0"
@@ -898,18 +898,18 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "39x59->39x1443/1441->1442",
+                                                                                                            "location": "1441->1442",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:block-statement-content",
-                                                                                                    "location": "39x60->41x17/1442->1486",
+                                                                                                    "location": "1442->1486",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "39x60->40x1/1442->1444",
+                                                                                                            "location": "1442->1444",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -917,7 +917,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "40x1->40x1465/1444->1464",
+                                                                                                            "location": "1444->1464",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -925,25 +925,25 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:block-html-element",
-                                                                                                            "location": "40x21->40x1469/1464->1468",
+                                                                                                            "location": "1464->1468",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "40x21->40x1469/1464->1468",
+                                                                                                                    "location": "1464->1468",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "40x21->40x1466/1464->1465",
+                                                                                                                            "location": "1464->1465",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "40x22->40x1468/1465->1467",
+                                                                                                                            "location": "1465->1467",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "40x24->40x1469/1467->1468",
+                                                                                                                            "location": "1467->1468",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ],
@@ -960,7 +960,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "40x25->41x1/1468->1470",
+                                                                                                            "location": "1468->1470",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -968,7 +968,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "41x1->41x1487/1470->1486",
+                                                                                                            "location": "1470->1486",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 16
@@ -978,21 +978,21 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "41x17->41x1492/1486->1491",
+                                                                                                    "location": "1486->1491",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "41x17->41x1489/1486->1488",
+                                                                                                            "location": "1486->1488",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "41x19->41x1491/1488->1490",
+                                                                                                            "location": "1488->1490",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "41x21->41x1492/1490->1491",
+                                                                                                            "location": "1490->1491",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
@@ -1004,7 +1004,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "41x22->43x1/1491->1495",
+                                                                                            "location": "1491->1495",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 2
@@ -1012,7 +1012,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "43x1->43x1512/1495->1511",
+                                                                                            "location": "1495->1511",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -1020,50 +1020,50 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:block-html-element",
-                                                                                            "location": "43x17->43x1566/1511->1565",
+                                                                                            "location": "1511->1565",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "43x17->43x1516/1511->1515",
+                                                                                                    "location": "1511->1515",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "43x17->43x1513/1511->1512",
+                                                                                                            "location": "1511->1512",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:html-id",
-                                                                                                            "location": "43x18->43x1515/1512->1514",
+                                                                                                            "location": "1512->1514",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "43x20->43x1516/1514->1515",
+                                                                                                            "location": "1514->1515",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:block-html-element-content",
-                                                                                                    "location": "43x21->43x1561/1515->1560",
+                                                                                                    "location": "1515->1560",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:inline-statement",
-                                                                                                            "location": "43x21->43x1561/1515->1560",
+                                                                                                            "location": "1515->1560",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "43x21->43x1517/1515->1516",
+                                                                                                                    "location": "1515->1516",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:at-id",
-                                                                                                                    "location": "43x22->43x1521/1516->1520",
+                                                                                                                    "location": "1516->1520",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:spaces",
-                                                                                                                    "location": "43x26->43x27/1520->1521",
+                                                                                                                    "location": "1520->1521",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "size": 1
@@ -1071,7 +1071,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:param",
-                                                                                                                    "location": "43x27->43x64/1521->1558",
+                                                                                                                    "location": "1521->1558",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "value": "renderItem(item, item_info.initIndex)"
@@ -1079,7 +1079,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "43x64->43x1561/1558->1560",
+                                                                                                                    "location": "1558->1560",
                                                                                                                     "children": []
                                                                                                                 }
                                                                                                             ]
@@ -1088,21 +1088,21 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "43x66->43x1566/1560->1565",
+                                                                                                    "location": "1560->1565",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "43x66->43x1563/1560->1562",
+                                                                                                            "location": "1560->1562",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:html-id",
-                                                                                                            "location": "43x68->43x1565/1562->1564",
+                                                                                                            "location": "1562->1564",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "43x70->43x1566/1564->1565",
+                                                                                                            "location": "1564->1565",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
@@ -1114,7 +1114,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "43x71->44x1/1565->1567",
+                                                                                            "location": "1565->1567",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1122,7 +1122,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "44x1->44x1584/1567->1583",
+                                                                                            "location": "1567->1583",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -1130,25 +1130,25 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:block-statement",
-                                                                                            "location": "44x17->50x22/1583->2273",
+                                                                                            "location": "1583->2273",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "44x17->44x1628/1583->1627",
+                                                                                                    "location": "1583->1627",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "44x17->44x1585/1583->1584",
+                                                                                                            "location": "1583->1584",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "44x18->44x1587/1584->1586",
+                                                                                                            "location": "1584->1586",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "44x20->44x1588/1586->1587",
+                                                                                                            "location": "1586->1587",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1156,7 +1156,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:param",
-                                                                                                            "location": "44x21->44x1627/1587->1626",
+                                                                                                            "location": "1587->1626",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "value": "(data.displayOptions.tableMode == true)"
@@ -1164,18 +1164,18 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "44x60->44x1628/1626->1627",
+                                                                                                            "location": "1626->1627",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:block-statement-content",
-                                                                                                    "location": "44x61->50x17/1627->2268",
+                                                                                                    "location": "1627->2268",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "44x61->45x1/1627->1629",
+                                                                                                            "location": "1627->1629",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1183,7 +1183,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "45x1->45x1650/1629->1649",
+                                                                                                            "location": "1629->1649",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -1191,21 +1191,21 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:inline-statement",
-                                                                                                            "location": "45x21->45x1699/1649->1698",
+                                                                                                            "location": "1649->1698",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "45x21->45x1651/1649->1650",
+                                                                                                                    "location": "1649->1650",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:at-id",
-                                                                                                                    "location": "45x22->45x1654/1650->1653",
+                                                                                                                    "location": "1650->1653",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:spaces",
-                                                                                                                    "location": "45x25->45x26/1653->1654",
+                                                                                                                    "location": "1653->1654",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "size": 1
@@ -1213,7 +1213,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:param",
-                                                                                                                    "location": "45x26->45x68/1654->1696",
+                                                                                                                    "location": "1654->1696",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "value": "checkboxLabelSplit = item.label.split('|')"
@@ -1221,14 +1221,14 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "45x68->45x1699/1696->1698",
+                                                                                                                    "location": "1696->1698",
                                                                                                                     "children": []
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "45x70->46x1/1698->1700",
+                                                                                                            "location": "1698->1700",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1236,7 +1236,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "46x1->46x1721/1700->1720",
+                                                                                                            "location": "1700->1720",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -1244,25 +1244,25 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:block-html-element",
-                                                                                                            "location": "46x21->46x1837/1720->1836",
+                                                                                                            "location": "1720->1836",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "46x21->46x1808/1720->1807",
+                                                                                                                    "location": "1720->1807",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "46x21->46x1722/1720->1721",
+                                                                                                                            "location": "1720->1721",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "46x22->46x1724/1721->1723",
+                                                                                                                            "location": "1721->1723",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "46x24->46x1725/1723->1724",
+                                                                                                                            "location": "1723->1724",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -1270,21 +1270,21 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                            "location": "46x25->46x1807/1724->1806",
+                                                                                                                            "location": "1724->1806",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "46x25->46x1726/1724->1725",
+                                                                                                                                    "location": "1724->1725",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                    "location": "46x26->46x1728/1725->1727",
+                                                                                                                                    "location": "1725->1727",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                    "location": "46x28->46x29/1727->1728",
+                                                                                                                                    "location": "1727->1728",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "size": 1
@@ -1292,7 +1292,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "46x29->46x105/1728->1804",
+                                                                                                                                    "location": "1728->1804",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1300,34 +1300,34 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "46x105->46x1807/1804->1806",
+                                                                                                                                    "location": "1804->1806",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "46x107->46x1808/1806->1807",
+                                                                                                                            "location": "1806->1807",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:block-html-element-content",
-                                                                                                                    "location": "46x108->46x1832/1807->1831",
+                                                                                                                    "location": "1807->1831",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:expression",
-                                                                                                                            "location": "46x108->46x1832/1807->1831",
+                                                                                                                            "location": "1807->1831",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "46x108->46x1810/1807->1809",
+                                                                                                                                    "location": "1807->1809",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "46x110->46x1831/1809->1830",
+                                                                                                                                    "location": "1809->1830",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "checkboxLabelSplit[0]"
@@ -1335,7 +1335,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "46x131->46x1832/1830->1831",
+                                                                                                                                    "location": "1830->1831",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
@@ -1344,21 +1344,21 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "46x132->46x1837/1831->1836",
+                                                                                                                    "location": "1831->1836",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "46x132->46x1834/1831->1833",
+                                                                                                                            "location": "1831->1833",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "46x134->46x1836/1833->1835",
+                                                                                                                            "location": "1833->1835",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "46x136->46x1837/1835->1836",
+                                                                                                                            "location": "1835->1836",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
@@ -1370,7 +1370,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "46x137->47x1/1836->1838",
+                                                                                                            "location": "1836->1838",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1378,7 +1378,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "47x1->47x1859/1838->1858",
+                                                                                                            "location": "1838->1858",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -1386,25 +1386,25 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:block-html-element",
-                                                                                                            "location": "47x21->47x1975/1858->1974",
+                                                                                                            "location": "1858->1974",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "47x21->47x1946/1858->1945",
+                                                                                                                    "location": "1858->1945",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "47x21->47x1860/1858->1859",
+                                                                                                                            "location": "1858->1859",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "47x22->47x1862/1859->1861",
+                                                                                                                            "location": "1859->1861",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "47x24->47x1863/1861->1862",
+                                                                                                                            "location": "1861->1862",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -1412,21 +1412,21 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                            "location": "47x25->47x1945/1862->1944",
+                                                                                                                            "location": "1862->1944",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "47x25->47x1864/1862->1863",
+                                                                                                                                    "location": "1862->1863",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                    "location": "47x26->47x1866/1863->1865",
+                                                                                                                                    "location": "1863->1865",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                    "location": "47x28->47x29/1865->1866",
+                                                                                                                                    "location": "1865->1866",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "size": 1
@@ -1434,7 +1434,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "47x29->47x105/1866->1942",
+                                                                                                                                    "location": "1866->1942",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1442,34 +1442,34 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "47x105->47x1945/1942->1944",
+                                                                                                                                    "location": "1942->1944",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "47x107->47x1946/1944->1945",
+                                                                                                                            "location": "1944->1945",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:block-html-element-content",
-                                                                                                                    "location": "47x108->47x1970/1945->1969",
+                                                                                                                    "location": "1945->1969",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:expression",
-                                                                                                                            "location": "47x108->47x1970/1945->1969",
+                                                                                                                            "location": "1945->1969",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "47x108->47x1948/1945->1947",
+                                                                                                                                    "location": "1945->1947",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "47x110->47x1969/1947->1968",
+                                                                                                                                    "location": "1947->1968",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "checkboxLabelSplit[1]"
@@ -1477,7 +1477,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "47x131->47x1970/1968->1969",
+                                                                                                                                    "location": "1968->1969",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
@@ -1486,21 +1486,21 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "47x132->47x1975/1969->1974",
+                                                                                                                    "location": "1969->1974",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "47x132->47x1972/1969->1971",
+                                                                                                                            "location": "1969->1971",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "47x134->47x1974/1971->1973",
+                                                                                                                            "location": "1971->1973",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "47x136->47x1975/1973->1974",
+                                                                                                                            "location": "1973->1974",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
@@ -1512,7 +1512,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "47x137->48x1/1974->1976",
+                                                                                                            "location": "1974->1976",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1520,7 +1520,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "48x1->48x1997/1976->1996",
+                                                                                                            "location": "1976->1996",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -1528,25 +1528,25 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:block-html-element",
-                                                                                                            "location": "48x21->48x2113/1996->2112",
+                                                                                                            "location": "1996->2112",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "48x21->48x2084/1996->2083",
+                                                                                                                    "location": "1996->2083",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "48x21->48x1998/1996->1997",
+                                                                                                                            "location": "1996->1997",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "48x22->48x2000/1997->1999",
+                                                                                                                            "location": "1997->1999",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "48x24->48x2001/1999->2000",
+                                                                                                                            "location": "1999->2000",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -1554,21 +1554,21 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                            "location": "48x25->48x2083/2000->2082",
+                                                                                                                            "location": "2000->2082",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "48x25->48x2002/2000->2001",
+                                                                                                                                    "location": "2000->2001",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                    "location": "48x26->48x2004/2001->2003",
+                                                                                                                                    "location": "2001->2003",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                    "location": "48x28->48x29/2003->2004",
+                                                                                                                                    "location": "2003->2004",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "size": 1
@@ -1576,7 +1576,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "48x29->48x105/2004->2080",
+                                                                                                                                    "location": "2004->2080",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1584,34 +1584,34 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "48x105->48x2083/2080->2082",
+                                                                                                                                    "location": "2080->2082",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "48x107->48x2084/2082->2083",
+                                                                                                                            "location": "2082->2083",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:block-html-element-content",
-                                                                                                                    "location": "48x108->48x2108/2083->2107",
+                                                                                                                    "location": "2083->2107",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:expression",
-                                                                                                                            "location": "48x108->48x2108/2083->2107",
+                                                                                                                            "location": "2083->2107",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "48x108->48x2086/2083->2085",
+                                                                                                                                    "location": "2083->2085",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "48x110->48x2107/2085->2106",
+                                                                                                                                    "location": "2085->2106",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "checkboxLabelSplit[2]"
@@ -1619,7 +1619,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "48x131->48x2108/2106->2107",
+                                                                                                                                    "location": "2106->2107",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
@@ -1628,21 +1628,21 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "48x132->48x2113/2107->2112",
+                                                                                                                    "location": "2107->2112",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "48x132->48x2110/2107->2109",
+                                                                                                                            "location": "2107->2109",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "48x134->48x2112/2109->2111",
+                                                                                                                            "location": "2109->2111",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "48x136->48x2113/2111->2112",
+                                                                                                                            "location": "2111->2112",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
@@ -1654,7 +1654,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "48x137->49x1/2112->2114",
+                                                                                                            "location": "2112->2114",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1662,7 +1662,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "49x1->49x2135/2114->2134",
+                                                                                                            "location": "2114->2134",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -1670,25 +1670,25 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:block-html-element",
-                                                                                                            "location": "49x21->49x2251/2134->2250",
+                                                                                                            "location": "2134->2250",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "49x21->49x2222/2134->2221",
+                                                                                                                    "location": "2134->2221",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "49x21->49x2136/2134->2135",
+                                                                                                                            "location": "2134->2135",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "49x22->49x2138/2135->2137",
+                                                                                                                            "location": "2135->2137",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "49x24->49x2139/2137->2138",
+                                                                                                                            "location": "2137->2138",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -1696,21 +1696,21 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                            "location": "49x25->49x2221/2138->2220",
+                                                                                                                            "location": "2138->2220",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "49x25->49x2140/2138->2139",
+                                                                                                                                    "location": "2138->2139",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                    "location": "49x26->49x2142/2139->2141",
+                                                                                                                                    "location": "2139->2141",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                    "location": "49x28->49x29/2141->2142",
+                                                                                                                                    "location": "2141->2142",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "size": 1
@@ -1718,7 +1718,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "49x29->49x105/2142->2218",
+                                                                                                                                    "location": "2142->2218",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1726,34 +1726,34 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "49x105->49x2221/2218->2220",
+                                                                                                                                    "location": "2218->2220",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "49x107->49x2222/2220->2221",
+                                                                                                                            "location": "2220->2221",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:block-html-element-content",
-                                                                                                                    "location": "49x108->49x2246/2221->2245",
+                                                                                                                    "location": "2221->2245",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:expression",
-                                                                                                                            "location": "49x108->49x2246/2221->2245",
+                                                                                                                            "location": "2221->2245",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "49x108->49x2224/2221->2223",
+                                                                                                                                    "location": "2221->2223",
                                                                                                                                     "children": []
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:param",
-                                                                                                                                    "location": "49x110->49x2245/2223->2244",
+                                                                                                                                    "location": "2223->2244",
                                                                                                                                     "children": [],
                                                                                                                                     "properties": {
                                                                                                                                         "value": "checkboxLabelSplit[3]"
@@ -1761,7 +1761,7 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "49x131->49x2246/2244->2245",
+                                                                                                                                    "location": "2244->2245",
                                                                                                                                     "children": []
                                                                                                                                 }
                                                                                                                             ]
@@ -1770,21 +1770,21 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "49x132->49x2251/2245->2250",
+                                                                                                                    "location": "2245->2250",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "49x132->49x2248/2245->2247",
+                                                                                                                            "location": "2245->2247",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "49x134->49x2250/2247->2249",
+                                                                                                                            "location": "2247->2249",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "49x136->49x2251/2249->2250",
+                                                                                                                            "location": "2249->2250",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
@@ -1796,7 +1796,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "49x137->50x1/2250->2252",
+                                                                                                            "location": "2250->2252",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1804,7 +1804,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "50x1->50x2269/2252->2268",
+                                                                                                            "location": "2252->2268",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 16
@@ -1814,21 +1814,21 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "50x17->50x2274/2268->2273",
+                                                                                                    "location": "2268->2273",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "50x17->50x2271/2268->2270",
+                                                                                                            "location": "2268->2270",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "50x19->50x2273/2270->2272",
+                                                                                                            "location": "2270->2272",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "50x21->50x2274/2272->2273",
+                                                                                                            "location": "2272->2273",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
@@ -1840,7 +1840,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "50x22->52x1/2273->2277",
+                                                                                            "location": "2273->2277",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 2
@@ -1848,7 +1848,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "52x1->52x2294/2277->2293",
+                                                                                            "location": "2277->2293",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -1856,25 +1856,25 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:block-statement",
-                                                                                            "location": "52x17->54x22/2293->2392",
+                                                                                            "location": "2293->2392",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "52x17->52x2343/2293->2342",
+                                                                                                    "location": "2293->2342",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "52x17->52x2295/2293->2294",
+                                                                                                            "location": "2293->2294",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "52x18->52x2297/2294->2296",
+                                                                                                            "location": "2294->2296",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "52x20->52x2298/2296->2297",
+                                                                                                            "location": "2296->2297",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1882,7 +1882,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:param",
-                                                                                                            "location": "52x21->52x2342/2297->2341",
+                                                                                                            "location": "2297->2341",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "value": "(item_index + 1) % data.numberOfColumns == 0"
@@ -1890,18 +1890,18 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "52x65->52x2343/2341->2342",
+                                                                                                            "location": "2341->2342",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:block-statement-content",
-                                                                                                    "location": "52x66->54x17/2342->2387",
+                                                                                                    "location": "2342->2387",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "52x66->53x1/2342->2344",
+                                                                                                            "location": "2342->2344",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1909,7 +1909,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "53x1->53x2365/2344->2364",
+                                                                                                            "location": "2344->2364",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -1917,25 +1917,25 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:block-html-element",
-                                                                                                            "location": "53x21->53x2370/2364->2369",
+                                                                                                            "location": "2364->2369",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "53x21->53x2370/2364->2369",
+                                                                                                                    "location": "2364->2369",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "53x21->53x2367/2364->2366",
+                                                                                                                            "location": "2364->2366",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:html-id",
-                                                                                                                            "location": "53x23->53x2369/2366->2368",
+                                                                                                                            "location": "2366->2368",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "53x25->53x2370/2368->2369",
+                                                                                                                            "location": "2368->2369",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ],
@@ -1952,7 +1952,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "53x26->54x1/2369->2371",
+                                                                                                            "location": "2369->2371",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -1960,7 +1960,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "54x1->54x2388/2371->2387",
+                                                                                                            "location": "2371->2387",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 16
@@ -1970,21 +1970,21 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "54x17->54x2393/2387->2392",
+                                                                                                    "location": "2387->2392",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "54x17->54x2390/2387->2389",
+                                                                                                            "location": "2387->2389",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "54x19->54x2392/2389->2391",
+                                                                                                            "location": "2389->2391",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "54x21->54x2393/2391->2392",
+                                                                                                            "location": "2391->2392",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
@@ -1996,7 +1996,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "54x22->55x1/2392->2394",
+                                                                                            "location": "2392->2394",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2004,7 +2004,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "55x1->55x2407/2394->2406",
+                                                                                            "location": "2394->2406",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 12
@@ -2014,21 +2014,21 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "55x13->55x2417/2406->2416",
+                                                                                    "location": "2406->2416",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "55x13->55x2409/2406->2408",
+                                                                                            "location": "2406->2408",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "55x15->55x2416/2408->2415",
+                                                                                            "location": "2408->2415",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "55x22->55x2417/2415->2416",
+                                                                                            "location": "2415->2416",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
@@ -2040,7 +2040,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "55x23->56x1/2416->2418",
+                                                                            "location": "2416->2418",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -2048,7 +2048,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "56x1->56x2431/2418->2430",
+                                                                            "location": "2418->2430",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -2058,21 +2058,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "56x13->56x2439/2430->2438",
+                                                                    "location": "2430->2438",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "56x13->56x2433/2430->2432",
+                                                                            "location": "2430->2432",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "56x15->56x2438/2432->2437",
+                                                                            "location": "2432->2437",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "56x20->56x2439/2437->2438",
+                                                                            "location": "2437->2438",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -2084,7 +2084,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "56x21->57x1/2438->2440",
+                                                            "location": "2438->2440",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2092,7 +2092,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "57x1->57x2449/2440->2448",
+                                                            "location": "2440->2448",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -2100,21 +2100,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "57x9->57x2510/2448->2509",
+                                                            "location": "2448->2509",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "57x9->57x2450/2448->2449",
+                                                                    "location": "2448->2449",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "57x10->57x2456/2449->2455",
+                                                                    "location": "2449->2455",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "57x16->57x17/2455->2456",
+                                                                    "location": "2455->2456",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2122,7 +2122,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "57x17->57x68/2456->2507",
+                                                                    "location": "2456->2507",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "(data.displayOptions.flowOrientation == 'vertical')"
@@ -2130,14 +2130,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "57x68->57x2510/2507->2509",
+                                                                    "location": "2507->2509",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "57x70->58x1/2509->2511",
+                                                            "location": "2509->2511",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2145,7 +2145,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "58x1->58x2524/2511->2523",
+                                                            "location": "2511->2523",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -2153,21 +2153,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "58x13->58x2561/2523->2560",
+                                                            "location": "2523->2560",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "58x13->58x2525/2523->2524",
+                                                                    "location": "2523->2524",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "58x14->58x2528/2524->2527",
+                                                                    "location": "2524->2527",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "58x17->58x18/2527->2528",
+                                                                    "location": "2527->2528",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2175,7 +2175,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "58x18->58x47/2528->2557",
+                                                                    "location": "2528->2557",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "lineCount = data.numberOfRows"
@@ -2183,7 +2183,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "58x47->58x48/2557->2558",
+                                                                    "location": "2557->2558",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2191,14 +2191,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "58x48->58x2561/2558->2560",
+                                                                    "location": "2558->2560",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "58x50->59x1/2560->2562",
+                                                            "location": "2560->2562",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2206,7 +2206,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "59x1->59x2575/2562->2574",
+                                                            "location": "2562->2574",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -2214,21 +2214,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "59x13->59x2617/2574->2616",
+                                                            "location": "2574->2616",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "59x13->59x2576/2574->2575",
+                                                                    "location": "2574->2575",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "59x14->59x2579/2575->2578",
+                                                                    "location": "2575->2578",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "59x17->59x18/2578->2579",
+                                                                    "location": "2578->2579",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2236,7 +2236,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "59x18->59x52/2579->2613",
+                                                                    "location": "2579->2613",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "columnCount = data.numberOfColumns"
@@ -2244,7 +2244,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "59x52->59x53/2613->2614",
+                                                                    "location": "2613->2614",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2252,14 +2252,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "59x53->59x2617/2614->2616",
+                                                                    "location": "2614->2616",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "59x55->60x1/2616->2618",
+                                                            "location": "2616->2618",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2267,7 +2267,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "60x1->60x2631/2618->2630",
+                                                            "location": "2618->2630",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -2275,21 +2275,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "60x13->60x2654/2630->2653",
+                                                            "location": "2630->2653",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "60x13->60x2632/2630->2631",
+                                                                    "location": "2630->2631",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "60x14->60x2635/2631->2634",
+                                                                    "location": "2631->2634",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "60x17->60x18/2634->2635",
+                                                                    "location": "2634->2635",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2297,7 +2297,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "60x18->60x33/2635->2650",
+                                                                    "location": "2635->2650",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "outputCount = 0"
@@ -2305,7 +2305,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "60x33->60x34/2650->2651",
+                                                                    "location": "2650->2651",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2313,14 +2313,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "60x34->60x2654/2651->2653",
+                                                                    "location": "2651->2653",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "60x36->61x1/2653->2655",
+                                                            "location": "2653->2655",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2328,7 +2328,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "61x1->61x2668/2655->2667",
+                                                            "location": "2655->2667",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -2336,21 +2336,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "61x13->61x2690/2667->2689",
+                                                            "location": "2667->2689",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "61x13->61x2669/2667->2668",
+                                                                    "location": "2667->2668",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "61x14->61x2672/2668->2671",
+                                                                    "location": "2668->2671",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "61x17->61x18/2671->2672",
+                                                                    "location": "2671->2672",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2358,7 +2358,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "61x18->61x32/2672->2686",
+                                                                    "location": "2672->2686",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "outputRows = 1"
@@ -2366,7 +2366,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "61x32->61x33/2686->2687",
+                                                                    "location": "2686->2687",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2374,14 +2374,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "61x33->61x2690/2687->2689",
+                                                                    "location": "2687->2689",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "61x35->62x1/2689->2691",
+                                                            "location": "2689->2691",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2389,7 +2389,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "62x1->62x2704/2691->2703",
+                                                            "location": "2691->2703",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -2397,36 +2397,36 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-html-element",
-                                                            "location": "62x13->79x21/2703->3424",
+                                                            "location": "2703->3424",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "62x13->62x2711/2703->2710",
+                                                                    "location": "2703->2710",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "62x13->62x2705/2703->2704",
+                                                                            "location": "2703->2704",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "62x14->62x2710/2704->2709",
+                                                                            "location": "2704->2709",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "62x19->62x2711/2709->2710",
+                                                                            "location": "2709->2710",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-html-element-content",
-                                                                    "location": "62x20->79x13/2710->3416",
+                                                                    "location": "2710->3416",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "62x20->63x1/2710->2712",
+                                                                            "location": "2710->2712",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -2434,7 +2434,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "63x1->63x2725/2712->2724",
+                                                                            "location": "2712->2724",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -2442,25 +2442,25 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:block-statement",
-                                                                            "location": "63x13->78x19/2724->3402",
+                                                                            "location": "2724->3402",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "63x13->63x2762/2724->2761",
+                                                                                    "location": "2724->2761",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "63x13->63x2726/2724->2725",
+                                                                                            "location": "2724->2725",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "63x14->63x2729/2725->2728",
+                                                                                            "location": "2725->2728",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "63x17->63x2730/2728->2729",
+                                                                                            "location": "2728->2729",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2468,7 +2468,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:param",
-                                                                                            "location": "63x18->63x2761/2729->2760",
+                                                                                            "location": "2729->2760",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "value": "var i = 0 ; i < lineCount ; i++"
@@ -2476,18 +2476,18 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "63x49->63x2762/2760->2761",
+                                                                                            "location": "2760->2761",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:block-statement-content",
-                                                                                    "location": "63x50->78x13/2761->3396",
+                                                                                    "location": "2761->3396",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "63x50->64x1/2761->2763",
+                                                                                            "location": "2761->2763",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2495,7 +2495,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "64x1->64x2780/2763->2779",
+                                                                                            "location": "2763->2779",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -2503,36 +2503,36 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:block-html-element",
-                                                                                            "location": "64x17->77x22/2779->3382",
+                                                                                            "location": "2779->3382",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "64x17->64x2784/2779->2783",
+                                                                                                    "location": "2779->2783",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "64x17->64x2781/2779->2780",
+                                                                                                            "location": "2779->2780",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:html-id",
-                                                                                                            "location": "64x18->64x2783/2780->2782",
+                                                                                                            "location": "2780->2782",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "64x20->64x2784/2782->2783",
+                                                                                                            "location": "2782->2783",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:block-html-element-content",
-                                                                                                    "location": "64x21->77x17/2783->3377",
+                                                                                                    "location": "2783->3377",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "64x21->65x1/2783->2785",
+                                                                                                            "location": "2783->2785",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -2540,7 +2540,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "65x1->65x2802/2785->2801",
+                                                                                                            "location": "2785->2801",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 16
@@ -2548,21 +2548,21 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:inline-statement",
-                                                                                                            "location": "65x17->65x2826/2801->2825",
+                                                                                                            "location": "2801->2825",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "65x17->65x2803/2801->2802",
+                                                                                                                    "location": "2801->2802",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:at-id",
-                                                                                                                    "location": "65x18->65x2806/2802->2805",
+                                                                                                                    "location": "2802->2805",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:spaces",
-                                                                                                                    "location": "65x21->65x22/2805->2806",
+                                                                                                                    "location": "2805->2806",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "size": 1
@@ -2570,7 +2570,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:param",
-                                                                                                                    "location": "65x22->65x38/2806->2822",
+                                                                                                                    "location": "2806->2822",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "value": "lastColCount = 0"
@@ -2578,7 +2578,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:spaces",
-                                                                                                                    "location": "65x38->65x39/2822->2823",
+                                                                                                                    "location": "2822->2823",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "size": 1
@@ -2586,14 +2586,14 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "65x39->65x2826/2823->2825",
+                                                                                                                    "location": "2823->2825",
                                                                                                                     "children": []
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "65x41->66x1/2825->2827",
+                                                                                                            "location": "2825->2827",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -2601,7 +2601,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "66x1->66x2844/2827->2843",
+                                                                                                            "location": "2827->2843",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 16
@@ -2609,25 +2609,25 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:block-statement",
-                                                                                                            "location": "66x17->75x23/2843->3307",
+                                                                                                            "location": "2843->3307",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "66x17->66x2884/2843->2883",
+                                                                                                                    "location": "2843->2883",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "66x17->66x2845/2843->2844",
+                                                                                                                            "location": "2843->2844",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:at-id",
-                                                                                                                            "location": "66x18->66x2848/2844->2847",
+                                                                                                                            "location": "2844->2847",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "66x21->66x2849/2847->2848",
+                                                                                                                            "location": "2847->2848",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -2635,7 +2635,7 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:param",
-                                                                                                                            "location": "66x22->66x2882/2848->2881",
+                                                                                                                            "location": "2848->2881",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "value": "var j = 0 ; j < columnCount ; j++"
@@ -2643,7 +2643,7 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "66x55->66x2883/2881->2882",
+                                                                                                                            "location": "2881->2882",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -2651,18 +2651,18 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "66x56->66x2884/2882->2883",
+                                                                                                                            "location": "2882->2883",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:block-statement-content",
-                                                                                                                    "location": "66x57->75x17/2883->3301",
+                                                                                                                    "location": "2883->3301",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:eols",
-                                                                                                                            "location": "66x57->67x1/2883->2885",
+                                                                                                                            "location": "2883->2885",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -2670,7 +2670,7 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "67x1->67x2906/2885->2905",
+                                                                                                                            "location": "2885->2905",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 20
@@ -2678,36 +2678,36 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:block-html-element",
-                                                                                                                            "location": "67x21->74x26/2905->3283",
+                                                                                                                            "location": "2905->3283",
                                                                                                                             "children": [
                                                                                                                                 {
                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                    "location": "67x21->67x2910/2905->2909",
+                                                                                                                                    "location": "2905->2909",
                                                                                                                                     "children": [
                                                                                                                                         {
                                                                                                                                             "type": "at-html:opening",
-                                                                                                                                            "location": "67x21->67x2907/2905->2906",
+                                                                                                                                            "location": "2905->2906",
                                                                                                                                             "children": []
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:html-id",
-                                                                                                                                            "location": "67x22->67x2909/2906->2908",
+                                                                                                                                            "location": "2906->2908",
                                                                                                                                             "children": []
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:closing",
-                                                                                                                                            "location": "67x24->67x2910/2908->2909",
+                                                                                                                                            "location": "2908->2909",
                                                                                                                                             "children": []
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:block-html-element-content",
-                                                                                                                                    "location": "67x25->74x21/2909->3278",
+                                                                                                                                    "location": "2909->3278",
                                                                                                                                     "children": [
                                                                                                                                         {
                                                                                                                                             "type": "at-html:eols",
-                                                                                                                                            "location": "67x25->68x1/2909->2911",
+                                                                                                                                            "location": "2909->2911",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 1
@@ -2715,7 +2715,7 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                            "location": "68x1->68x2932/2911->2931",
+                                                                                                                                            "location": "2911->2931",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 20
@@ -2723,21 +2723,21 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                                            "location": "68x21->68x2966/2931->2965",
+                                                                                                                                            "location": "2931->2965",
                                                                                                                                             "children": [
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                                    "location": "68x21->68x2933/2931->2932",
+                                                                                                                                                    "location": "2931->2932",
                                                                                                                                                     "children": []
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                                    "location": "68x22->68x2936/2932->2935",
+                                                                                                                                                    "location": "2932->2935",
                                                                                                                                                     "children": []
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                                    "location": "68x25->68x26/2935->2936",
+                                                                                                                                                    "location": "2935->2936",
                                                                                                                                                     "children": [],
                                                                                                                                                     "properties": {
                                                                                                                                                         "size": 1
@@ -2745,7 +2745,7 @@
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:param",
-                                                                                                                                                    "location": "68x26->68x53/2936->2963",
+                                                                                                                                                    "location": "2936->2963",
                                                                                                                                                     "children": [],
                                                                                                                                                     "properties": {
                                                                                                                                                         "value": "itemIndex = (j*lineCount)+i"
@@ -2753,14 +2753,14 @@
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                                    "location": "68x53->68x2966/2963->2965",
+                                                                                                                                                    "location": "2963->2965",
                                                                                                                                                     "children": []
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:eols",
-                                                                                                                                            "location": "68x55->69x1/2965->2967",
+                                                                                                                                            "location": "2965->2967",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 1
@@ -2768,7 +2768,7 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                            "location": "69x1->69x2988/2967->2987",
+                                                                                                                                            "location": "2967->2987",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 20
@@ -2776,25 +2776,25 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:block-statement",
-                                                                                                                                            "location": "69x21->72x26/2987->3198",
+                                                                                                                                            "location": "2987->3198",
                                                                                                                                             "children": [
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                                    "location": "69x21->69x3034/2987->3033",
+                                                                                                                                                    "location": "2987->3033",
                                                                                                                                                     "children": [
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:opening",
-                                                                                                                                                            "location": "69x21->69x2989/2987->2988",
+                                                                                                                                                            "location": "2987->2988",
                                                                                                                                                             "children": []
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:at-id",
-                                                                                                                                                            "location": "69x22->69x2991/2988->2990",
+                                                                                                                                                            "location": "2988->2990",
                                                                                                                                                             "children": []
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                                            "location": "69x24->69x2992/2990->2991",
+                                                                                                                                                            "location": "2990->2991",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "size": 1
@@ -2802,7 +2802,7 @@
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:param",
-                                                                                                                                                            "location": "69x25->69x3033/2991->3032",
+                                                                                                                                                            "location": "2991->3032",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "value": "(itemIndex < data.itemsView.items.length)"
@@ -2810,18 +2810,18 @@
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:closing",
-                                                                                                                                                            "location": "69x66->69x3034/3032->3033",
+                                                                                                                                                            "location": "3032->3033",
                                                                                                                                                             "children": []
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:block-statement-content",
-                                                                                                                                                    "location": "69x67->72x21/3033->3193",
+                                                                                                                                                    "location": "3033->3193",
                                                                                                                                                     "children": [
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:eols",
-                                                                                                                                                            "location": "69x67->70x1/3033->3035",
+                                                                                                                                                            "location": "3033->3035",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "size": 1
@@ -2829,7 +2829,7 @@
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                                            "location": "70x1->70x3060/3035->3059",
+                                                                                                                                                            "location": "3035->3059",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "size": 24
@@ -2837,21 +2837,21 @@
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                                                            "location": "70x25->70x3111/3059->3110",
+                                                                                                                                                            "location": "3059->3110",
                                                                                                                                                             "children": [
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                                                    "location": "70x25->70x3061/3059->3060",
+                                                                                                                                                                    "location": "3059->3060",
                                                                                                                                                                     "children": []
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                                                    "location": "70x26->70x3064/3060->3063",
+                                                                                                                                                                    "location": "3060->3063",
                                                                                                                                                                     "children": []
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                                                    "location": "70x29->70x30/3063->3064",
+                                                                                                                                                                    "location": "3063->3064",
                                                                                                                                                                     "children": [],
                                                                                                                                                                     "properties": {
                                                                                                                                                                         "size": 1
@@ -2859,7 +2859,7 @@
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:param",
-                                                                                                                                                                    "location": "70x30->70x74/3064->3108",
+                                                                                                                                                                    "location": "3064->3108",
                                                                                                                                                                     "children": [],
                                                                                                                                                                     "properties": {
                                                                                                                                                                         "value": "item = data.itemsView.items[itemIndex].value"
@@ -2867,14 +2867,14 @@
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                                                    "location": "70x74->70x3111/3108->3110",
+                                                                                                                                                                    "location": "3108->3110",
                                                                                                                                                                     "children": []
                                                                                                                                                                 }
                                                                                                                                                             ]
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:eols",
-                                                                                                                                                            "location": "70x76->71x1/3110->3112",
+                                                                                                                                                            "location": "3110->3112",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "size": 1
@@ -2882,7 +2882,7 @@
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                                            "location": "71x1->71x3137/3112->3136",
+                                                                                                                                                            "location": "3112->3136",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "size": 24
@@ -2890,21 +2890,21 @@
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                                                            "location": "71x25->71x3172/3136->3171",
+                                                                                                                                                            "location": "3136->3171",
                                                                                                                                                             "children": [
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                                                    "location": "71x25->71x3138/3136->3137",
+                                                                                                                                                                    "location": "3136->3137",
                                                                                                                                                                     "children": []
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                                                    "location": "71x26->71x3142/3137->3141",
+                                                                                                                                                                    "location": "3137->3141",
                                                                                                                                                                     "children": []
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                                                    "location": "71x30->71x31/3141->3142",
+                                                                                                                                                                    "location": "3141->3142",
                                                                                                                                                                     "children": [],
                                                                                                                                                                     "properties": {
                                                                                                                                                                         "size": 1
@@ -2912,7 +2912,7 @@
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:param",
-                                                                                                                                                                    "location": "71x31->71x58/3142->3169",
+                                                                                                                                                                    "location": "3142->3169",
                                                                                                                                                                     "children": [],
                                                                                                                                                                     "properties": {
                                                                                                                                                                         "value": "renderItem(item, itemIndex)"
@@ -2920,14 +2920,14 @@
                                                                                                                                                                 },
                                                                                                                                                                 {
                                                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                                                    "location": "71x58->71x3172/3169->3171",
+                                                                                                                                                                    "location": "3169->3171",
                                                                                                                                                                     "children": []
                                                                                                                                                                 }
                                                                                                                                                             ]
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:eols",
-                                                                                                                                                            "location": "71x60->72x1/3171->3173",
+                                                                                                                                                            "location": "3171->3173",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "size": 1
@@ -2935,7 +2935,7 @@
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                                            "location": "72x1->72x3194/3173->3193",
+                                                                                                                                                            "location": "3173->3193",
                                                                                                                                                             "children": [],
                                                                                                                                                             "properties": {
                                                                                                                                                                 "size": 20
@@ -2945,21 +2945,21 @@
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                                    "location": "72x21->72x3199/3193->3198",
+                                                                                                                                                    "location": "3193->3198",
                                                                                                                                                     "children": [
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:opening",
-                                                                                                                                                            "location": "72x21->72x3196/3193->3195",
+                                                                                                                                                            "location": "3193->3195",
                                                                                                                                                             "children": []
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:at-id",
-                                                                                                                                                            "location": "72x23->72x3198/3195->3197",
+                                                                                                                                                            "location": "3195->3197",
                                                                                                                                                             "children": []
                                                                                                                                                         },
                                                                                                                                                         {
                                                                                                                                                             "type": "at-html:closing",
-                                                                                                                                                            "location": "72x25->72x3199/3197->3198",
+                                                                                                                                                            "location": "3197->3198",
                                                                                                                                                             "children": []
                                                                                                                                                         }
                                                                                                                                                     ]
@@ -2971,7 +2971,7 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:eols",
-                                                                                                                                            "location": "72x26->73x1/3198->3200",
+                                                                                                                                            "location": "3198->3200",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 1
@@ -2979,7 +2979,7 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                            "location": "73x1->73x3221/3200->3220",
+                                                                                                                                            "location": "3200->3220",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 20
@@ -2987,21 +2987,21 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:inline-statement",
-                                                                                                                                            "location": "73x21->73x3257/3220->3256",
+                                                                                                                                            "location": "3220->3256",
                                                                                                                                             "children": [
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:opening",
-                                                                                                                                                    "location": "73x21->73x3222/3220->3221",
+                                                                                                                                                    "location": "3220->3221",
                                                                                                                                                     "children": []
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:at-id",
-                                                                                                                                                    "location": "73x22->73x3225/3221->3224",
+                                                                                                                                                    "location": "3221->3224",
                                                                                                                                                     "children": []
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:spaces",
-                                                                                                                                                    "location": "73x25->73x26/3224->3225",
+                                                                                                                                                    "location": "3224->3225",
                                                                                                                                                     "children": [],
                                                                                                                                                     "properties": {
                                                                                                                                                         "size": 1
@@ -3009,7 +3009,7 @@
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:param",
-                                                                                                                                                    "location": "73x26->73x55/3225->3254",
+                                                                                                                                                    "location": "3225->3254",
                                                                                                                                                     "children": [],
                                                                                                                                                     "properties": {
                                                                                                                                                         "value": "outputCount = outputCount + 1"
@@ -3017,14 +3017,14 @@
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                                    "location": "73x55->73x3257/3254->3256",
+                                                                                                                                                    "location": "3254->3256",
                                                                                                                                                     "children": []
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:eols",
-                                                                                                                                            "location": "73x57->74x1/3256->3258",
+                                                                                                                                            "location": "3256->3258",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 1
@@ -3032,7 +3032,7 @@
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:spaces",
-                                                                                                                                            "location": "74x1->74x3279/3258->3278",
+                                                                                                                                            "location": "3258->3278",
                                                                                                                                             "children": [],
                                                                                                                                             "properties": {
                                                                                                                                                 "size": 20
@@ -3042,21 +3042,21 @@
                                                                                                                                 },
                                                                                                                                 {
                                                                                                                                     "type": "at-html:closing",
-                                                                                                                                    "location": "74x21->74x3284/3278->3283",
+                                                                                                                                    "location": "3278->3283",
                                                                                                                                     "children": [
                                                                                                                                         {
                                                                                                                                             "type": "at-html:opening",
-                                                                                                                                            "location": "74x21->74x3281/3278->3280",
+                                                                                                                                            "location": "3278->3280",
                                                                                                                                             "children": []
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:html-id",
-                                                                                                                                            "location": "74x23->74x3283/3280->3282",
+                                                                                                                                            "location": "3280->3282",
                                                                                                                                             "children": []
                                                                                                                                         },
                                                                                                                                         {
                                                                                                                                             "type": "at-html:closing",
-                                                                                                                                            "location": "74x25->74x3284/3282->3283",
+                                                                                                                                            "location": "3282->3283",
                                                                                                                                             "children": []
                                                                                                                                         }
                                                                                                                                     ]
@@ -3068,7 +3068,7 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:eols",
-                                                                                                                            "location": "74x26->75x1/3283->3285",
+                                                                                                                            "location": "3283->3285",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 1
@@ -3076,7 +3076,7 @@
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:spaces",
-                                                                                                                            "location": "75x1->75x3302/3285->3301",
+                                                                                                                            "location": "3285->3301",
                                                                                                                             "children": [],
                                                                                                                             "properties": {
                                                                                                                                 "size": 16
@@ -3086,21 +3086,21 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "75x17->75x3308/3301->3307",
+                                                                                                                    "location": "3301->3307",
                                                                                                                     "children": [
                                                                                                                         {
                                                                                                                             "type": "at-html:opening",
-                                                                                                                            "location": "75x17->75x3304/3301->3303",
+                                                                                                                            "location": "3301->3303",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:at-id",
-                                                                                                                            "location": "75x19->75x3307/3303->3306",
+                                                                                                                            "location": "3303->3306",
                                                                                                                             "children": []
                                                                                                                         },
                                                                                                                         {
                                                                                                                             "type": "at-html:closing",
-                                                                                                                            "location": "75x22->75x3308/3306->3307",
+                                                                                                                            "location": "3306->3307",
                                                                                                                             "children": []
                                                                                                                         }
                                                                                                                     ]
@@ -3112,7 +3112,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "75x23->76x1/3307->3309",
+                                                                                                            "location": "3307->3309",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -3120,7 +3120,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "76x1->76x3326/3309->3325",
+                                                                                                            "location": "3309->3325",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 16
@@ -3128,21 +3128,21 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:inline-statement",
-                                                                                                            "location": "76x17->76x3360/3325->3359",
+                                                                                                            "location": "3325->3359",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "76x17->76x3327/3325->3326",
+                                                                                                                    "location": "3325->3326",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:at-id",
-                                                                                                                    "location": "76x18->76x3330/3326->3329",
+                                                                                                                    "location": "3326->3329",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:spaces",
-                                                                                                                    "location": "76x21->76x22/3329->3330",
+                                                                                                                    "location": "3329->3330",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "size": 1
@@ -3150,7 +3150,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:param",
-                                                                                                                    "location": "76x22->76x49/3330->3357",
+                                                                                                                    "location": "3330->3357",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "value": "outputRows = outputRows + 1"
@@ -3158,14 +3158,14 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "76x49->76x3360/3357->3359",
+                                                                                                                    "location": "3357->3359",
                                                                                                                     "children": []
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "76x51->77x1/3359->3361",
+                                                                                                            "location": "3359->3361",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -3173,7 +3173,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "77x1->77x3378/3361->3377",
+                                                                                                            "location": "3361->3377",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 16
@@ -3183,21 +3183,21 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "77x17->77x3383/3377->3382",
+                                                                                                    "location": "3377->3382",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "77x17->77x3380/3377->3379",
+                                                                                                            "location": "3377->3379",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:html-id",
-                                                                                                            "location": "77x19->77x3382/3379->3381",
+                                                                                                            "location": "3379->3381",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "77x21->77x3383/3381->3382",
+                                                                                                            "location": "3381->3382",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
@@ -3209,7 +3209,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "77x22->78x1/3382->3384",
+                                                                                            "location": "3382->3384",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -3217,7 +3217,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "78x1->78x3397/3384->3396",
+                                                                                            "location": "3384->3396",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 12
@@ -3227,21 +3227,21 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "78x13->78x3403/3396->3402",
+                                                                                    "location": "3396->3402",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "78x13->78x3399/3396->3398",
+                                                                                            "location": "3396->3398",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "78x15->78x3402/3398->3401",
+                                                                                            "location": "3398->3401",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "78x18->78x3403/3401->3402",
+                                                                                            "location": "3401->3402",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
@@ -3253,7 +3253,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "78x19->79x1/3402->3404",
+                                                                            "location": "3402->3404",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -3261,7 +3261,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "79x1->79x3417/3404->3416",
+                                                                            "location": "3404->3416",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -3271,21 +3271,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "79x13->79x3425/3416->3424",
+                                                                    "location": "3416->3424",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "79x13->79x3419/3416->3418",
+                                                                            "location": "3416->3418",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "79x15->79x3424/3418->3423",
+                                                                            "location": "3418->3423",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "79x20->79x3425/3423->3424",
+                                                                            "location": "3423->3424",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -3297,7 +3297,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "79x21->80x1/3424->3426",
+                                                            "location": "3424->3426",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3305,7 +3305,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "80x1->80x3435/3426->3434",
+                                                            "location": "3426->3434",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3313,28 +3313,28 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "80x9->80x3442/3434->3441",
+                                                            "location": "3434->3441",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "80x9->80x3436/3434->3435",
+                                                                    "location": "3434->3435",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "80x10->80x3440/3435->3439",
+                                                                    "location": "3435->3439",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "80x14->80x3442/3439->3441",
+                                                                    "location": "3439->3441",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "80x16->81x1/3441->3443",
+                                                            "location": "3441->3443",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3342,7 +3342,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "81x1->81x3456/3443->3455",
+                                                            "location": "3443->3455",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -3350,25 +3350,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-statement",
-                                                            "location": "81x13->83x23/3455->3578",
+                                                            "location": "3455->3578",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "81x13->81x3492/3455->3491",
+                                                                    "location": "3455->3491",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "81x13->81x3457/3455->3456",
+                                                                            "location": "3455->3456",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "81x14->81x3464/3456->3463",
+                                                                            "location": "3456->3463",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "81x21->81x3465/3463->3464",
+                                                                            "location": "3463->3464",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -3376,7 +3376,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:param",
-                                                                            "location": "81x22->81x3491/3464->3490",
+                                                                            "location": "3464->3490",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "value": "item inView data.itemsView"
@@ -3384,18 +3384,18 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "81x48->81x3492/3490->3491",
+                                                                            "location": "3490->3491",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-statement-content",
-                                                                    "location": "81x49->83x13/3491->3568",
+                                                                    "location": "3491->3568",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "81x49->82x1/3491->3493",
+                                                                            "location": "3491->3493",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -3403,7 +3403,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "82x1->82x3510/3493->3509",
+                                                                            "location": "3493->3509",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -3411,21 +3411,21 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-statement",
-                                                                            "location": "82x17->82x3555/3509->3554",
+                                                                            "location": "3509->3554",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "82x17->82x3511/3509->3510",
+                                                                                    "location": "3509->3510",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-id",
-                                                                                    "location": "82x18->82x3515/3510->3514",
+                                                                                    "location": "3510->3514",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "82x22->82x23/3514->3515",
+                                                                                    "location": "3514->3515",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -3433,7 +3433,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "82x23->82x60/3515->3552",
+                                                                                    "location": "3515->3552",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "renderItem(item, item_info.initIndex)"
@@ -3441,14 +3441,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "82x60->82x3555/3552->3554",
+                                                                                    "location": "3552->3554",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "82x62->83x1/3554->3556",
+                                                                            "location": "3554->3556",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -3456,7 +3456,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "83x1->83x3569/3556->3568",
+                                                                            "location": "3556->3568",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -3466,21 +3466,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "83x13->83x3579/3568->3578",
+                                                                    "location": "3568->3578",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "83x13->83x3571/3568->3570",
+                                                                            "location": "3568->3570",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "83x15->83x3578/3570->3577",
+                                                                            "location": "3570->3577",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "83x22->83x3579/3577->3578",
+                                                                            "location": "3577->3578",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -3492,7 +3492,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "83x23->84x1/3578->3580",
+                                                            "location": "3578->3580",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3500,7 +3500,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "84x1->84x3589/3580->3588",
+                                                            "location": "3580->3588",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3510,21 +3510,21 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "84x9->84x3594/3588->3593",
+                                                    "location": "3588->3593",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "84x9->84x3591/3588->3590",
+                                                            "location": "3588->3590",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "84x11->84x3593/3590->3592",
+                                                            "location": "3590->3592",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "84x13->84x3594/3592->3593",
+                                                            "location": "3592->3593",
                                                             "children": []
                                                         }
                                                     ]
@@ -3536,7 +3536,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "84x14->85x1/3593->3595",
+                                            "location": "3593->3595",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3544,7 +3544,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "85x1->85x3600/3595->3599",
+                                            "location": "3595->3599",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -3554,21 +3554,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "85x5->85x3608/3599->3607",
+                                    "location": "3599->3607",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "85x5->85x3602/3599->3601",
+                                            "location": "3599->3601",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "85x7->85x3607/3601->3606",
+                                            "location": "3601->3606",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "85x12->85x3608/3606->3607",
+                                            "location": "3606->3607",
                                             "children": []
                                         }
                                     ]
@@ -3580,7 +3580,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "85x13->87x1/3607->3611",
+                            "location": "3607->3611",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -3588,7 +3588,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "87x1->87x3616/3611->3615",
+                            "location": "3611->3615",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -3596,25 +3596,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "87x5->123x13/3615->4773",
+                            "location": "3615->4773",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "87x5->87x3640/3615->3639",
+                                    "location": "3615->3639",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "87x5->87x3617/3615->3616",
+                                            "location": "3615->3616",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "87x6->87x3622/3616->3621",
+                                            "location": "3616->3621",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "87x11->87x3623/3621->3622",
+                                            "location": "3621->3622",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3622,7 +3622,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "87x12->87x3639/3622->3638",
+                                            "location": "3622->3638",
                                             "children": [],
                                             "properties": {
                                                 "value": "renderItem(item)"
@@ -3630,18 +3630,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "87x28->87x3640/3638->3639",
+                                            "location": "3638->3639",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "87x29->123x5/3639->4765",
+                                    "location": "3639->4765",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "87x29->89x1/3639->3643",
+                                            "location": "3639->3643",
                                             "children": [],
                                             "properties": {
                                                 "size": 2
@@ -3649,7 +3649,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "89x1->89x3652/3643->3651",
+                                            "location": "3643->3651",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -3657,21 +3657,21 @@
                                         },
                                         {
                                             "type": "at-html:inline-statement",
-                                            "location": "89x9->89x3682/3651->3681",
+                                            "location": "3651->3681",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "89x9->89x3653/3651->3652",
+                                                    "location": "3651->3652",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-id",
-                                                    "location": "89x10->89x3656/3652->3655",
+                                                    "location": "3652->3655",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:spaces",
-                                                    "location": "89x13->89x14/3655->3656",
+                                                    "location": "3655->3656",
                                                     "children": [],
                                                     "properties": {
                                                         "size": 1
@@ -3679,7 +3679,7 @@
                                                 },
                                                 {
                                                     "type": "at-html:param",
-                                                    "location": "89x14->89x37/3656->3679",
+                                                    "location": "3656->3679",
                                                     "children": [],
                                                     "properties": {
                                                         "value": "checkboxLabel = \"Error\""
@@ -3687,14 +3687,14 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "89x37->89x3682/3679->3681",
+                                                    "location": "3679->3681",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "89x39->90x1/3681->3683",
+                                            "location": "3681->3683",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3702,7 +3702,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "90x1->90x3692/3683->3691",
+                                            "location": "3683->3691",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -3710,25 +3710,25 @@
                                         },
                                         {
                                             "type": "at-html:block-statement",
-                                            "location": "90x9->96x14/3691->4050",
+                                            "location": "3691->4050",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "90x9->90x3740/3691->3739",
+                                                    "location": "3691->3739",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "90x9->90x3693/3691->3692",
+                                                            "location": "3691->3692",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "90x10->90x3695/3692->3694",
+                                                            "location": "3692->3694",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "90x12->90x3696/3694->3695",
+                                                            "location": "3694->3695",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3736,7 +3736,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "90x13->90x3739/3695->3738",
+                                                            "location": "3695->3738",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "(data.displayOptions.listDisplay == 'code')"
@@ -3744,18 +3744,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "90x56->90x3740/3738->3739",
+                                                            "location": "3738->3739",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "90x57->96x9/3739->4045",
+                                                    "location": "3739->4045",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "90x57->91x1/3739->3741",
+                                                            "location": "3739->3741",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3763,7 +3763,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "91x1->91x3754/3741->3753",
+                                                            "location": "3741->3753",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -3771,21 +3771,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "91x13->91x3787/3753->3786",
+                                                            "location": "3753->3786",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "91x13->91x3755/3753->3754",
+                                                                    "location": "3753->3754",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "91x14->91x3758/3754->3757",
+                                                                    "location": "3754->3757",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "91x17->91x18/3757->3758",
+                                                                    "location": "3757->3758",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3793,7 +3793,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "91x18->91x44/3758->3784",
+                                                                    "location": "3758->3784",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = item.value"
@@ -3801,14 +3801,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "91x44->91x3787/3784->3786",
+                                                                    "location": "3784->3786",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "91x46->92x1/3786->3788",
+                                                            "location": "3786->3788",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3816,7 +3816,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "92x1->92x3797/3788->3796",
+                                                            "location": "3788->3796",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3824,21 +3824,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "92x9->92x3851/3796->3850",
+                                                            "location": "3796->3850",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "92x9->92x3798/3796->3797",
+                                                                    "location": "3796->3797",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "92x10->92x3804/3797->3803",
+                                                                    "location": "3797->3803",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "92x16->92x17/3803->3804",
+                                                                    "location": "3803->3804",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3846,7 +3846,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "92x17->92x61/3804->3848",
+                                                                    "location": "3804->3848",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "(data.displayOptions.listDisplay == 'label')"
@@ -3854,14 +3854,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "92x61->92x3851/3848->3850",
+                                                                    "location": "3848->3850",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "92x63->93x1/3850->3852",
+                                                            "location": "3850->3852",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3869,7 +3869,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "93x1->93x3865/3852->3864",
+                                                            "location": "3852->3864",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -3877,21 +3877,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "93x13->93x3898/3864->3897",
+                                                            "location": "3864->3897",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "93x13->93x3866/3864->3865",
+                                                                    "location": "3864->3865",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "93x14->93x3869/3865->3868",
+                                                                    "location": "3865->3868",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "93x17->93x18/3868->3869",
+                                                                    "location": "3868->3869",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3899,7 +3899,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "93x18->93x44/3869->3895",
+                                                                    "location": "3869->3895",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = item.label"
@@ -3907,14 +3907,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "93x44->93x3898/3895->3897",
+                                                                    "location": "3895->3897",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "93x46->94x1/3897->3899",
+                                                            "location": "3897->3899",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3922,7 +3922,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "94x1->94x3908/3899->3907",
+                                                            "location": "3899->3907",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3930,21 +3930,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "94x9->94x3961/3907->3960",
+                                                            "location": "3907->3960",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "94x9->94x3909/3907->3908",
+                                                                    "location": "3907->3908",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "94x10->94x3915/3908->3914",
+                                                                    "location": "3908->3914",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "94x16->94x17/3914->3915",
+                                                                    "location": "3914->3915",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3952,7 +3952,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "94x17->94x60/3915->3958",
+                                                                    "location": "3915->3958",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "(data.displayOptions.listDisplay == 'both')"
@@ -3960,14 +3960,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "94x60->94x3961/3958->3960",
+                                                                    "location": "3958->3960",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "94x62->95x1/3960->3962",
+                                                            "location": "3960->3962",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3975,7 +3975,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "95x1->95x3975/3962->3974",
+                                                            "location": "3962->3974",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -3983,21 +3983,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "95x13->95x4036/3974->4035",
+                                                            "location": "3974->4035",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "95x13->95x3976/3974->3975",
+                                                                    "location": "3974->3975",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "95x14->95x3979/3975->3978",
+                                                                    "location": "3975->3978",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "95x17->95x18/3978->3979",
+                                                                    "location": "3978->3979",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -4005,7 +4005,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "95x18->95x71/3979->4032",
+                                                                    "location": "3979->4032",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = item.label + \" (\" + item.value + \") \""
@@ -4013,7 +4013,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "95x71->95x72/4032->4033",
+                                                                    "location": "4032->4033",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -4021,14 +4021,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "95x72->95x4036/4033->4035",
+                                                                    "location": "4033->4035",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "95x74->96x1/4035->4037",
+                                                            "location": "4035->4037",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4036,7 +4036,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "96x1->96x4046/4037->4045",
+                                                            "location": "4037->4045",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -4046,21 +4046,21 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "96x9->96x4051/4045->4050",
+                                                    "location": "4045->4050",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "96x9->96x4048/4045->4047",
+                                                            "location": "4045->4047",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "96x11->96x4050/4047->4049",
+                                                            "location": "4047->4049",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "96x13->96x4051/4049->4050",
+                                                            "location": "4049->4050",
                                                             "children": []
                                                         }
                                                     ]
@@ -4072,7 +4072,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "96x14->97x1/4050->4052",
+                                            "location": "4050->4052",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -4080,7 +4080,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "97x1->97x4061/4052->4060",
+                                            "location": "4052->4060",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -4088,25 +4088,25 @@
                                         },
                                         {
                                             "type": "at-html:block-statement",
-                                            "location": "97x9->99x14/4060->4158",
+                                            "location": "4060->4158",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "97x9->97x4105/4060->4104",
+                                                    "location": "4060->4104",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "97x9->97x4062/4060->4061",
+                                                            "location": "4060->4061",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "97x10->97x4064/4061->4063",
+                                                            "location": "4061->4063",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "97x12->97x4065/4063->4064",
+                                                            "location": "4063->4064",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4114,7 +4114,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "97x13->97x4104/4064->4103",
+                                                            "location": "4064->4103",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "(data.displayOptions.tableMode == true)"
@@ -4122,18 +4122,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "97x52->97x4105/4103->4104",
+                                                            "location": "4103->4104",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "97x53->99x9/4104->4153",
+                                                    "location": "4104->4153",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "97x53->98x1/4104->4106",
+                                                            "location": "4104->4106",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4141,7 +4141,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "98x1->98x4119/4106->4118",
+                                                            "location": "4106->4118",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -4149,21 +4149,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "98x13->98x4144/4118->4143",
+                                                            "location": "4118->4143",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "98x13->98x4120/4118->4119",
+                                                                    "location": "4118->4119",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "98x14->98x4123/4119->4122",
+                                                                    "location": "4119->4122",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "98x17->98x18/4122->4123",
+                                                                    "location": "4122->4123",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -4171,7 +4171,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "98x18->98x36/4123->4141",
+                                                                    "location": "4123->4141",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = \"\""
@@ -4179,14 +4179,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "98x36->98x4144/4141->4143",
+                                                                    "location": "4141->4143",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "98x38->99x1/4143->4145",
+                                                            "location": "4143->4145",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4194,7 +4194,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "99x1->99x4154/4145->4153",
+                                                            "location": "4145->4153",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -4204,21 +4204,21 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "99x9->99x4159/4153->4158",
+                                                    "location": "4153->4158",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "99x9->99x4156/4153->4155",
+                                                            "location": "4153->4155",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "99x11->99x4158/4155->4157",
+                                                            "location": "4155->4157",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "99x13->99x4159/4157->4158",
+                                                            "location": "4157->4158",
                                                             "children": []
                                                         }
                                                     ]
@@ -4230,7 +4230,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "99x14->102x1/4158->4164",
+                                            "location": "4158->4164",
                                             "children": [],
                                             "properties": {
                                                 "size": 3
@@ -4238,7 +4238,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "102x1->102x4173/4164->4172",
+                                            "location": "4164->4172",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -4246,32 +4246,32 @@
                                         },
                                         {
                                             "type": "at-html:inline-widget",
-                                            "location": "102x9->121x12/4172->4757",
+                                            "location": "4172->4757",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "102x9->102x4174/4172->4173",
+                                                    "location": "4172->4173",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-widget-id",
-                                                    "location": "102x10->102x4188/4173->4187",
+                                                    "location": "4173->4187",
                                                     "children": [
                                                         {
                                                             "type": "at-html:at-widget-library",
-                                                            "location": "102x11->102x4179/4174->4178",
+                                                            "location": "4174->4178",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-name",
-                                                            "location": "102x16->102x4188/4179->4187",
+                                                            "location": "4179->4187",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:spaces",
-                                                    "location": "102x24->102x25/4187->4188",
+                                                    "location": "4187->4188",
                                                     "children": [],
                                                     "properties": {
                                                         "size": 1
@@ -4279,7 +4279,7 @@
                                                 },
                                                 {
                                                     "type": "at-html:param",
-                                                    "location": "102x25->121x10/4188->4755",
+                                                    "location": "4188->4755",
                                                     "children": [],
                                                     "properties": {
                                                         "value": "{\r\n            label: checkboxLabel,\r\n            onchange: {\r\n                fn: \"itemClick\",\r\n                args: {\r\n                    item : item,\r\n                    itemIdx : item.index\r\n                }\r\n            },\r\n            id: 'listItem' + item.index,\r\n            bind:{\r\n                \"value\": {\r\n                    inside: item, to: 'selected'\r\n                },\r\n                \"disabled\" : {\r\n                    inside : item, to: \"currentlyDisabled\"\r\n                    }\r\n            },\r\n            value: item.selected\r\n        }"
@@ -4287,14 +4287,14 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "121x10->121x4758/4755->4757",
+                                                    "location": "4755->4757",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "121x12->123x1/4757->4761",
+                                            "location": "4757->4761",
                                             "children": [],
                                             "properties": {
                                                 "size": 2
@@ -4302,7 +4302,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "123x1->123x4766/4761->4765",
+                                            "location": "4761->4765",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -4312,21 +4312,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "123x5->123x4774/4765->4773",
+                                    "location": "4765->4773",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "123x5->123x4768/4765->4767",
+                                            "location": "4765->4767",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "123x7->123x4773/4767->4772",
+                                            "location": "4767->4772",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "123x12->123x4774/4772->4773",
+                                            "location": "4772->4773",
                                             "children": []
                                         }
                                     ]
@@ -4338,7 +4338,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "123x13->125x1/4773->4777",
+                            "location": "4773->4777",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -4346,7 +4346,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "125x1->125x4782/4777->4781",
+                            "location": "4777->4781",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -4354,25 +4354,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "125x5->158x13/4781->5947",
+                            "location": "4781->5947",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "125x5->125x4798/4781->4797",
+                                    "location": "4781->4797",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "125x5->125x4783/4781->4782",
+                                            "location": "4781->4782",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "125x6->125x4788/4782->4787",
+                                            "location": "4782->4787",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "125x11->125x4789/4787->4788",
+                                            "location": "4787->4788",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -4380,7 +4380,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "125x12->125x4797/4788->4796",
+                                            "location": "4788->4796",
                                             "children": [],
                                             "properties": {
                                                 "value": "footer()"
@@ -4388,18 +4388,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "125x20->125x4798/4796->4797",
+                                            "location": "4796->4797",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "125x21->158x5/4797->5939",
+                                    "location": "4797->5939",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "125x21->126x1/4797->4799",
+                                            "location": "4797->4799",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -4407,7 +4407,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "126x1->126x4808/4799->4807",
+                                            "location": "4799->4807",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -4415,25 +4415,25 @@
                                         },
                                         {
                                             "type": "at-html:block-html-element",
-                                            "location": "126x9->157x15/4807->5933",
+                                            "location": "4807->5933",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "126x9->126x4849/4807->4848",
+                                                    "location": "4807->4848",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "126x9->126x4809/4807->4808",
+                                                            "location": "4807->4808",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:html-id",
-                                                            "location": "126x10->126x4812/4808->4811",
+                                                            "location": "4808->4811",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "126x13->126x4813/4811->4812",
+                                                            "location": "4811->4812",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4441,21 +4441,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:text",
-                                                            "location": "126x14->126x4820/4812->4819",
+                                                            "location": "4812->4819",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:expression",
-                                                            "location": "126x21->126x4847/4819->4846",
+                                                            "location": "4819->4846",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "126x21->126x4822/4819->4821",
+                                                                    "location": "4819->4821",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "126x23->126x4846/4821->4845",
+                                                                    "location": "4821->4845",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "data.skin.cssClassFooter"
@@ -4463,30 +4463,30 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "126x47->126x4847/4845->4846",
+                                                                    "location": "4845->4846",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:text",
-                                                            "location": "126x48->126x4848/4846->4847",
+                                                            "location": "4846->4847",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "126x49->126x4849/4847->4848",
+                                                            "location": "4847->4848",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-html-element-content",
-                                                    "location": "126x50->157x9/4848->5927",
+                                                    "location": "4848->5927",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "126x50->127x1/4848->4850",
+                                                            "location": "4848->4850",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4494,7 +4494,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "127x1->127x4863/4850->4862",
+                                                            "location": "4850->4862",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -4502,25 +4502,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-html-element",
-                                                            "location": "127x13->136x19/4862->5203",
+                                                            "location": "4862->5203",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "127x13->127x4888/4862->4887",
+                                                                    "location": "4862->4887",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "127x13->127x4864/4862->4863",
+                                                                            "location": "4862->4863",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "127x14->127x4867/4863->4866",
+                                                                            "location": "4863->4866",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "127x17->127x4868/4866->4867",
+                                                                            "location": "4866->4867",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4528,23 +4528,23 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:text",
-                                                                            "location": "127x18->127x4887/4867->4886",
+                                                                            "location": "4867->4886",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "127x37->127x4888/4886->4887",
+                                                                            "location": "4886->4887",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-html-element-content",
-                                                                    "location": "127x38->136x13/4887->5197",
+                                                                    "location": "4887->5197",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "127x38->128x1/4887->4889",
+                                                                            "location": "4887->4889",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4552,7 +4552,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "128x1->128x4906/4889->4905",
+                                                                            "location": "4889->4905",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -4560,32 +4560,32 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-widget",
-                                                                            "location": "128x17->135x20/4905->5183",
+                                                                            "location": "4905->5183",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "128x17->128x4907/4905->4906",
+                                                                                    "location": "4905->4906",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-widget-id",
-                                                                                    "location": "128x18->128x4917/4906->4916",
+                                                                                    "location": "4906->4916",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:at-widget-library",
-                                                                                            "location": "128x19->128x4912/4907->4911",
+                                                                                            "location": "4907->4911",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-widget-name",
-                                                                                            "location": "128x24->128x4917/4912->4916",
+                                                                                            "location": "4912->4916",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "128x28->128x29/4916->4917",
+                                                                                    "location": "4916->4917",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -4593,7 +4593,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "128x29->135x18/4917->5181",
+                                                                                    "location": "4917->5181",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "{\r\n                    label : footerRes.selectAll,\r\n                    sclass : 'multiSelectFooter',\r\n                    onclick : {\r\n                        fn : \"selectAll\",\r\n                        scope : moduleCtrl\r\n                    }\r\n                }"
@@ -4601,14 +4601,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "135x18->135x5184/5181->5183",
+                                                                                    "location": "5181->5183",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "135x20->136x1/5183->5185",
+                                                                            "location": "5183->5185",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4616,7 +4616,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "136x1->136x5198/5185->5197",
+                                                                            "location": "5185->5197",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -4626,21 +4626,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "136x13->136x5204/5197->5203",
+                                                                    "location": "5197->5203",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "136x13->136x5200/5197->5199",
+                                                                            "location": "5197->5199",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "136x15->136x5203/5199->5202",
+                                                                            "location": "5199->5202",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "136x18->136x5204/5202->5203",
+                                                                            "location": "5202->5203",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -4652,7 +4652,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "136x19->137x1/5203->5205",
+                                                            "location": "5203->5205",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4660,7 +4660,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "137x1->137x5218/5205->5217",
+                                                            "location": "5205->5217",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -4668,25 +4668,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-html-element",
-                                                            "location": "137x13->146x20/5217->5581",
+                                                            "location": "5217->5581",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "137x13->137x5278/5217->5277",
+                                                                    "location": "5217->5277",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "137x13->137x5219/5217->5218",
+                                                                            "location": "5217->5218",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "137x14->137x5223/5218->5222",
+                                                                            "location": "5218->5222",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "137x18->137x5224/5222->5223",
+                                                                            "location": "5222->5223",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4694,23 +4694,23 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:text",
-                                                                            "location": "137x19->137x5277/5223->5276",
+                                                                            "location": "5223->5276",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "137x72->137x5278/5276->5277",
+                                                                            "location": "5276->5277",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-html-element-content",
-                                                                    "location": "137x73->146x13/5277->5574",
+                                                                    "location": "5277->5574",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "137x73->138x1/5277->5279",
+                                                                            "location": "5277->5279",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4718,7 +4718,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "138x1->138x5296/5279->5295",
+                                                                            "location": "5279->5295",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -4726,32 +4726,32 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-widget",
-                                                                            "location": "138x17->145x20/5295->5560",
+                                                                            "location": "5295->5560",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "138x17->138x5297/5295->5296",
+                                                                                    "location": "5295->5296",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-widget-id",
-                                                                                    "location": "138x18->138x5307/5296->5306",
+                                                                                    "location": "5296->5306",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:at-widget-library",
-                                                                                            "location": "138x19->138x5302/5297->5301",
+                                                                                            "location": "5297->5301",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-widget-name",
-                                                                                            "location": "138x24->138x5307/5302->5306",
+                                                                                            "location": "5302->5306",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "138x28->138x29/5306->5307",
+                                                                                    "location": "5306->5307",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -4759,7 +4759,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "138x29->145x18/5307->5558",
+                                                                                    "location": "5307->5558",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "{\r\n                    label:footerRes.close,\r\n                    sclass : 'multiSelectFooter',\r\n                    onclick: {\r\n                        fn: \"close\",\r\n                        scope: moduleCtrl\r\n                    }\r\n                }"
@@ -4767,14 +4767,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "145x18->145x5561/5558->5560",
+                                                                                    "location": "5558->5560",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "145x20->146x1/5560->5562",
+                                                                            "location": "5560->5562",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4782,7 +4782,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "146x1->146x5575/5562->5574",
+                                                                            "location": "5562->5574",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -4792,21 +4792,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "146x13->146x5582/5574->5581",
+                                                                    "location": "5574->5581",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "146x13->146x5577/5574->5576",
+                                                                            "location": "5574->5576",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "146x15->146x5581/5576->5580",
+                                                                            "location": "5576->5580",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "146x19->146x5582/5580->5581",
+                                                                            "location": "5580->5581",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -4818,7 +4818,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "146x20->147x1/5581->5583",
+                                                            "location": "5581->5583",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4826,7 +4826,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "147x1->147x5596/5583->5595",
+                                                            "location": "5583->5595",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -4834,36 +4834,36 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-html-element",
-                                                            "location": "147x13->156x20/5595->5917",
+                                                            "location": "5595->5917",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "147x13->147x5602/5595->5601",
+                                                                    "location": "5595->5601",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "147x13->147x5597/5595->5596",
+                                                                            "location": "5595->5596",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "147x14->147x5601/5596->5600",
+                                                                            "location": "5596->5600",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "147x18->147x5602/5600->5601",
+                                                                            "location": "5600->5601",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-html-element-content",
-                                                                    "location": "147x19->156x13/5601->5910",
+                                                                    "location": "5601->5910",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "147x19->148x1/5601->5603",
+                                                                            "location": "5601->5603",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4871,7 +4871,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "148x1->148x5620/5603->5619",
+                                                                            "location": "5603->5619",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -4879,32 +4879,32 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-widget",
-                                                                            "location": "148x17->155x20/5619->5896",
+                                                                            "location": "5619->5896",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "148x17->148x5621/5619->5620",
+                                                                                    "location": "5619->5620",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-widget-id",
-                                                                                    "location": "148x18->148x5631/5620->5630",
+                                                                                    "location": "5620->5630",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:at-widget-library",
-                                                                                            "location": "148x19->148x5626/5621->5625",
+                                                                                            "location": "5621->5625",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-widget-name",
-                                                                                            "location": "148x24->148x5631/5626->5630",
+                                                                                            "location": "5626->5630",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "148x28->148x29/5630->5631",
+                                                                                    "location": "5630->5631",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -4912,7 +4912,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "148x29->155x18/5631->5894",
+                                                                                    "location": "5631->5894",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "{\r\n                    label:footerRes.deselectAll,\r\n                    sclass : 'multiSelectFooter',\r\n                    onclick: {\r\n                        fn: \"deselectAll\",\r\n                        scope: moduleCtrl\r\n                    }\r\n                }"
@@ -4920,14 +4920,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "155x18->155x5897/5894->5896",
+                                                                                    "location": "5894->5896",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "155x20->156x1/5896->5898",
+                                                                            "location": "5896->5898",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -4935,7 +4935,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "156x1->156x5911/5898->5910",
+                                                                            "location": "5898->5910",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -4945,21 +4945,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "156x13->156x5918/5910->5917",
+                                                                    "location": "5910->5917",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "156x13->156x5913/5910->5912",
+                                                                            "location": "5910->5912",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:html-id",
-                                                                            "location": "156x15->156x5917/5912->5916",
+                                                                            "location": "5912->5916",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "156x19->156x5918/5916->5917",
+                                                                            "location": "5916->5917",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -4971,7 +4971,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "156x20->157x1/5917->5919",
+                                                            "location": "5917->5919",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -4979,7 +4979,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "157x1->157x5928/5919->5927",
+                                                            "location": "5919->5927",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -4989,21 +4989,21 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "157x9->157x5934/5927->5933",
+                                                    "location": "5927->5933",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "157x9->157x5930/5927->5929",
+                                                            "location": "5927->5929",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:html-id",
-                                                            "location": "157x11->157x5933/5929->5932",
+                                                            "location": "5929->5932",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "157x14->157x5934/5932->5933",
+                                                            "location": "5932->5933",
                                                             "children": []
                                                         }
                                                     ]
@@ -5015,7 +5015,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "157x15->158x1/5933->5935",
+                                            "location": "5933->5935",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -5023,7 +5023,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "158x1->158x5940/5935->5939",
+                                            "location": "5935->5939",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -5033,21 +5033,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "158x5->158x5948/5939->5947",
+                                    "location": "5939->5947",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "158x5->158x5942/5939->5941",
+                                            "location": "5939->5941",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "158x7->158x5947/5941->5946",
+                                            "location": "5941->5946",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "158x12->158x5948/5946->5947",
+                                            "location": "5946->5947",
                                             "children": []
                                         }
                                     ]
@@ -5059,7 +5059,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "158x13->160x1/5947->5951",
+                            "location": "5947->5951",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -5069,21 +5069,21 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "160x1->160x5963/5951->5962",
+                    "location": "5951->5962",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "160x1->160x5954/5951->5953",
+                            "location": "5951->5953",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "160x3->160x5962/5953->5961",
+                            "location": "5953->5961",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "160x11->160x5963/5961->5962",
+                            "location": "5961->5962",
                             "children": []
                         }
                     ]
@@ -5095,7 +5095,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "160x12->161x1/5962->5964",
+            "location": "5962->5964",
             "children": [],
             "properties": {
                 "size": 1

--- a/test/app/node_modules/modes/at-html/parser/index/startEmpty-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startEmpty-output.json
@@ -1,5 +1,5 @@
 {
     "type": "at-html:root",
-    "location": "1x1->1x1/0->0",
+    "location": "0->0",
     "children": []
 }

--- a/test/app/node_modules/modes/at-html/parser/index/startFive-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startFive-output.json
@@ -1,28 +1,28 @@
 {
     "type": "at-html:root",
-    "location": "1x1->2x3/0->20",
+    "location": "0->20",
     "children": [
         {
             "type": "at-html:block-statement",
-            "location": "1x1->1x17/0->16",
+            "location": "0->16",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x17/0->16",
+                    "location": "0->16",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x1->1x2/0->1",
+                            "location": "0->1",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "1x2->1x7/1->6",
+                            "location": "1->6",
                             "children": []
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "1x7->1x8/6->7",
+                            "location": "6->7",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -30,7 +30,7 @@
                         },
                         {
                             "type": "at-html:param",
-                            "location": "1x8->1x16/7->15",
+                            "location": "7->15",
                             "children": [],
                             "properties": {
                                 "value": "ahjbjd()"
@@ -38,7 +38,7 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x16->1x17/15->16",
+                            "location": "15->16",
                             "children": []
                         }
                     ],
@@ -52,7 +52,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "1x17->2x1/16->18",
+            "location": "16->18",
             "children": [],
             "properties": {
                 "size": 1
@@ -60,7 +60,7 @@
         },
         {
             "type": "at-html:statement",
-            "location": "2x1->2x21/18->20",
+            "location": "18->20",
             "children": [],
             "properties": {
                 "errors": [

--- a/test/app/node_modules/modes/at-html/parser/index/startFour-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startFour-output.json
@@ -1,28 +1,28 @@
 {
     "type": "at-html:root",
-    "location": "1x1->4x9/0->36",
+    "location": "0->36",
     "children": [
         {
             "type": "at-html:block-statement",
-            "location": "1x1->3x9/0->26",
+            "location": "0->26",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x8/0->7",
+                    "location": "0->7",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x1->1x2/0->1",
+                            "location": "0->1",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "1x2->1x7/1->6",
+                            "location": "1->6",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x7->1x8/6->7",
+                            "location": "6->7",
                             "children": []
                         }
                     ],
@@ -35,11 +35,11 @@
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "1x8->3x1/7->18",
+                    "location": "7->18",
                     "children": [
                         {
                             "type": "at-html:eols",
-                            "location": "1x8->2x1/7->9",
+                            "location": "7->9",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -47,25 +47,25 @@
                         },
                         {
                             "type": "at-html:block-html-element",
-                            "location": "2x1->2x17/9->16",
+                            "location": "9->16",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "2x1->2x17/9->16",
+                                    "location": "9->16",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "2x1->2x11/9->10",
+                                            "location": "9->10",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:html-id",
-                                            "location": "2x2->2x16/10->15",
+                                            "location": "10->15",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "2x7->2x17/15->16",
+                                            "location": "15->16",
                                             "children": []
                                         }
                                     ],
@@ -79,7 +79,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "2x8->3x1/16->18",
+                            "location": "16->18",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -89,21 +89,21 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "3x1->3x27/18->26",
+                    "location": "18->26",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "3x1->3x21/18->20",
+                            "location": "18->20",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "3x3->3x26/20->25",
+                            "location": "20->25",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "3x8->3x27/25->26",
+                            "location": "25->26",
                             "children": []
                         }
                     ]
@@ -112,7 +112,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "3x9->4x1/26->28",
+            "location": "26->28",
             "children": [],
             "properties": {
                 "size": 1
@@ -120,25 +120,25 @@
         },
         {
             "type": "at-html:block-html-element",
-            "location": "4x1->4x37/28->36",
+            "location": "28->36",
             "children": [
                 {
                     "type": "at-html:closing",
-                    "location": "4x1->4x37/28->36",
+                    "location": "28->36",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "4x1->4x31/28->30",
+                            "location": "28->30",
                             "children": []
                         },
                         {
                             "type": "at-html:html-id",
-                            "location": "4x3->4x36/30->35",
+                            "location": "30->35",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "4x8->4x37/35->36",
+                            "location": "35->36",
                             "children": []
                         }
                     ],

--- a/test/app/node_modules/modes/at-html/parser/index/startNine-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startNine-output.json
@@ -1,19 +1,19 @@
 {
     "type": "at-html:root",
-    "location": "1x1->2x1/0->16",
+    "location": "0->16",
     "children": [
         {
             "type": "at-html:expression",
-            "location": "1x1->1x15/0->14",
+            "location": "0->14",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x3/0->2",
+                    "location": "0->2",
                     "children": []
                 },
                 {
                     "type": "at-html:param",
-                    "location": "1x3->1x14/2->13",
+                    "location": "2->13",
                     "children": [],
                     "properties": {
                         "value": "abnskdjbksa"
@@ -21,7 +21,7 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x14->1x15/13->14",
+                    "location": "13->14",
                     "children": []
                 }
             ],
@@ -33,7 +33,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "1x15->2x1/14->16",
+            "location": "14->16",
             "children": [],
             "properties": {
                 "size": 1

--- a/test/app/node_modules/modes/at-html/parser/index/startOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startOne-output.json
@@ -1,31 +1,31 @@
 {
     "type": "at-html:root",
-    "location": "1x1->143x1/0->5425",
+    "location": "0->5425",
     "children": [
         {
             "type": "at-html:multi-line-comment",
-            "location": "1x1->14x4/0->606",
+            "location": "0->606",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x3/0->2",
+                    "location": "0->2",
                     "children": []
                 },
                 {
                     "type": "at-html:content",
-                    "location": "1x3->14x2/2->604",
+                    "location": "2->604",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "14x2->14x607/604->606",
+                    "location": "604->606",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "14x4->16x1/606->610",
+            "location": "606->610",
             "children": [],
             "properties": {
                 "size": 2
@@ -33,23 +33,23 @@
         },
         {
             "type": "at-html:single-line-comment",
-            "location": "16x1->16x646/610->645",
+            "location": "610->645",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "16x1->16x613/610->612",
+                    "location": "610->612",
                     "children": []
                 },
                 {
                     "type": "at-html:content",
-                    "location": "16x3->16x646/612->645",
+                    "location": "612->645",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "16x36->17x1/645->647",
+            "location": "645->647",
             "children": [],
             "properties": {
                 "size": 1
@@ -57,25 +57,25 @@
         },
         {
             "type": "at-html:block-statement",
-            "location": "17x1->142x12/647->5423",
+            "location": "647->5423",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "17x1->23x3/647->828",
+                    "location": "647->828",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "17x1->17x649/647->648",
+                            "location": "647->648",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "17x2->17x657/648->656",
+                            "location": "648->656",
                             "children": []
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "17x10->17x658/656->657",
+                            "location": "656->657",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -83,7 +83,7 @@
                         },
                         {
                             "type": "at-html:param",
-                            "location": "17x11->23x2/657->827",
+                            "location": "657->827",
                             "children": [],
                             "properties": {
                                 "value": "{\r\n    $classpath:'aria.widgets.form.templates.TemplateMultiSelect',\r\n    $hasScript:true,\r\n    $res:{\r\n      footerRes : 'aria.resources.multiselect.FooterRes'\r\n    }\r\n}"
@@ -91,18 +91,18 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "23x2->23x829/827->828",
+                            "location": "827->828",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "23x3->142x1/828->5412",
+                    "location": "828->5412",
                     "children": [
                         {
                             "type": "at-html:eols",
-                            "location": "23x3->24x1/828->830",
+                            "location": "828->830",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -110,7 +110,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "24x1->24x835/830->834",
+                            "location": "830->834",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -118,25 +118,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "24x5->32x13/834->1169",
+                            "location": "834->1169",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "24x5->24x849/834->848",
+                                    "location": "834->848",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "24x5->24x836/834->835",
+                                            "location": "834->835",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "24x6->24x841/835->840",
+                                            "location": "835->840",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "24x11->24x842/840->841",
+                                            "location": "840->841",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -144,7 +144,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "24x12->24x848/841->847",
+                                            "location": "841->847",
                                             "children": [],
                                             "properties": {
                                                 "value": "main()"
@@ -152,18 +152,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "24x18->24x849/847->848",
+                                            "location": "847->848",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "24x19->32x5/848->1161",
+                                    "location": "848->1161",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "24x19->25x1/848->850",
+                                            "location": "848->850",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -171,7 +171,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "25x1->25x859/850->858",
+                                            "location": "850->858",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -179,23 +179,23 @@
                                         },
                                         {
                                             "type": "at-html:single-line-comment",
-                                            "location": "25x9->25x921/858->920",
+                                            "location": "858->920",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "25x9->25x861/858->860",
+                                                    "location": "858->860",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:content",
-                                                    "location": "25x11->25x921/860->920",
+                                                    "location": "860->920",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "25x71->26x1/920->922",
+                                            "location": "920->922",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -203,7 +203,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "26x1->26x931/922->930",
+                                            "location": "922->930",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -211,36 +211,36 @@
                                         },
                                         {
                                             "type": "at-html:block-widget",
-                                            "location": "26x9->31x21/930->1155",
+                                            "location": "930->1155",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "26x9->26x951/930->950",
+                                                    "location": "930->950",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "26x9->26x932/930->931",
+                                                            "location": "930->931",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-id",
-                                                            "location": "26x10->26x941/931->940",
+                                                            "location": "931->940",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:at-widget-library",
-                                                                    "location": "26x11->26x937/932->936",
+                                                                    "location": "932->936",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-widget-name",
-                                                                    "location": "26x16->26x941/937->940",
+                                                                    "location": "937->940",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "26x19->26x942/940->941",
+                                                            "location": "940->941",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -248,7 +248,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "26x20->26x950/941->949",
+                                                            "location": "941->949",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "data.cfg"
@@ -256,18 +256,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "26x28->26x951/949->950",
+                                                            "location": "949->950",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "26x29->31x9/950->1143",
+                                                    "location": "950->1143",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "26x29->27x1/950->952",
+                                                            "location": "950->952",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -275,7 +275,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "27x1->27x969/952->968",
+                                                            "location": "952->968",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 16
@@ -283,21 +283,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "27x17->27x1015/968->1014",
+                                                            "location": "968->1014",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "27x17->27x970/968->969",
+                                                                    "location": "968->969",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "27x18->27x977/969->976",
+                                                                    "location": "969->976",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "27x25->27x26/976->977",
+                                                                    "location": "976->977",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -305,7 +305,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "27x26->27x60/977->1011",
+                                                                    "location": "977->1011",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "{id: 'Items', macro: 'renderList'}"
@@ -313,7 +313,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "27x60->27x61/1011->1012",
+                                                                    "location": "1011->1012",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -321,14 +321,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "27x61->27x1015/1012->1014",
+                                                                    "location": "1012->1014",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "27x63->28x1/1014->1016",
+                                                            "location": "1014->1016",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -336,7 +336,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "28x1->28x1033/1016->1032",
+                                                            "location": "1016->1032",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 16
@@ -344,25 +344,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-statement",
-                                                            "location": "28x17->30x22/1032->1133",
+                                                            "location": "1032->1133",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "28x17->28x1073/1032->1072",
+                                                                    "location": "1032->1072",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "28x17->28x1034/1032->1033",
+                                                                            "location": "1032->1033",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "28x18->28x1036/1033->1035",
+                                                                            "location": "1033->1035",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "28x20->28x1037/1035->1036",
+                                                                            "location": "1035->1036",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -370,7 +370,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:param",
-                                                                            "location": "28x21->28x1072/1036->1071",
+                                                                            "location": "1036->1071",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "value": "(data.displayOptions.displayFooter)"
@@ -378,18 +378,18 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "28x56->28x1073/1071->1072",
+                                                                            "location": "1071->1072",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-statement-content",
-                                                                    "location": "28x57->30x17/1072->1128",
+                                                                    "location": "1072->1128",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "28x57->29x1/1072->1074",
+                                                                            "location": "1072->1074",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -397,7 +397,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "29x1->29x1095/1074->1094",
+                                                                            "location": "1074->1094",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 20
@@ -405,21 +405,21 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-statement",
-                                                                            "location": "29x21->29x1111/1094->1110",
+                                                                            "location": "1094->1110",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "29x21->29x1096/1094->1095",
+                                                                                    "location": "1094->1095",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-id",
-                                                                                    "location": "29x22->29x1100/1095->1099",
+                                                                                    "location": "1095->1099",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "29x26->29x27/1099->1100",
+                                                                                    "location": "1099->1100",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -427,7 +427,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "29x27->29x35/1100->1108",
+                                                                                    "location": "1100->1108",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "footer()"
@@ -435,14 +435,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "29x35->29x1111/1108->1110",
+                                                                                    "location": "1108->1110",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "29x37->30x1/1110->1112",
+                                                                            "location": "1110->1112",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -450,7 +450,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "30x1->30x1129/1112->1128",
+                                                                            "location": "1112->1128",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -460,21 +460,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "30x17->30x1134/1128->1133",
+                                                                    "location": "1128->1133",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "30x17->30x1131/1128->1130",
+                                                                            "location": "1128->1130",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "30x19->30x1133/1130->1132",
+                                                                            "location": "1130->1132",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "30x21->30x1134/1132->1133",
+                                                                            "location": "1132->1133",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -483,7 +483,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "30x22->31x1/1133->1135",
+                                                            "location": "1133->1135",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -491,7 +491,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "31x1->31x1144/1135->1143",
+                                                            "location": "1135->1143",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -501,32 +501,32 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "31x9->31x1156/1143->1155",
+                                                    "location": "1143->1155",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "31x9->31x1146/1143->1145",
+                                                            "location": "1143->1145",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-id",
-                                                            "location": "31x11->31x1155/1145->1154",
+                                                            "location": "1145->1154",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:at-widget-library",
-                                                                    "location": "31x12->31x1151/1146->1150",
+                                                                    "location": "1146->1150",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-widget-name",
-                                                                    "location": "31x17->31x1155/1151->1154",
+                                                                    "location": "1151->1154",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "31x20->31x1156/1154->1155",
+                                                            "location": "1154->1155",
                                                             "children": []
                                                         }
                                                     ]
@@ -535,7 +535,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "31x21->32x1/1155->1157",
+                                            "location": "1155->1157",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -543,7 +543,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "32x1->32x1162/1157->1161",
+                                            "location": "1157->1161",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -553,21 +553,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "32x5->32x1170/1161->1169",
+                                    "location": "1161->1169",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "32x5->32x1164/1161->1163",
+                                            "location": "1161->1163",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "32x7->32x1169/1163->1168",
+                                            "location": "1163->1168",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "32x12->32x1170/1168->1169",
+                                            "location": "1168->1169",
                                             "children": []
                                         }
                                     ]
@@ -576,7 +576,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "32x13->34x1/1169->1173",
+                            "location": "1169->1173",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -584,7 +584,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "34x1->34x1178/1173->1177",
+                            "location": "1173->1177",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -592,25 +592,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "34x5->75x13/1177->3330",
+                            "location": "1177->3330",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "34x5->34x1202/1177->1201",
+                                    "location": "1177->1201",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "34x5->34x1179/1177->1178",
+                                            "location": "1177->1178",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "34x6->34x1184/1178->1183",
+                                            "location": "1178->1183",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "34x11->34x1185/1183->1184",
+                                            "location": "1183->1184",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -618,7 +618,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "34x12->34x1201/1184->1200",
+                                            "location": "1184->1200",
                                             "children": [],
                                             "properties": {
                                                 "value": "renderList(item)"
@@ -626,18 +626,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "34x28->34x1202/1200->1201",
+                                            "location": "1200->1201",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "34x29->75x5/1201->3322",
+                                    "location": "1201->3322",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "34x29->35x1/1201->1203",
+                                            "location": "1201->1203",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -645,7 +645,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "35x1->35x1212/1203->1211",
+                                            "location": "1203->1211",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -653,25 +653,25 @@
                                         },
                                         {
                                             "type": "at-html:block-statement",
-                                            "location": "35x9->74x14/1211->3316",
+                                            "location": "1211->3316",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "35x9->35x1270/1211->1269",
+                                                    "location": "1211->1269",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "35x9->35x1213/1211->1212",
+                                                            "location": "1211->1212",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "35x10->35x1215/1212->1214",
+                                                            "location": "1212->1214",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "35x12->35x1216/1214->1215",
+                                                            "location": "1214->1215",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -679,7 +679,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "35x13->35x1269/1215->1268",
+                                                            "location": "1215->1268",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "(data.displayOptions.flowOrientation == 'horizontal')"
@@ -687,18 +687,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "35x66->35x1270/1268->1269",
+                                                            "location": "1268->1269",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "35x67->74x9/1269->3311",
+                                                    "location": "1269->3311",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "35x67->36x1/1269->1271",
+                                                            "location": "1269->1271",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -706,7 +706,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "36x1->36x1284/1271->1283",
+                                                            "location": "1271->1283",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -714,23 +714,23 @@
                                                         },
                                                         {
                                                             "type": "at-html:single-line-comment",
-                                                            "location": "36x13->36x1311/1283->1310",
+                                                            "location": "1283->1310",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "36x13->36x1286/1283->1285",
+                                                                    "location": "1283->1285",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:content",
-                                                                    "location": "36x15->36x1311/1285->1310",
+                                                                    "location": "1285->1310",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "36x40->37x1/1310->1312",
+                                                            "location": "1310->1312",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -738,7 +738,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "37x1->37x1325/1312->1324",
+                                                            "location": "1312->1324",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -746,25 +746,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-statement",
-                                                            "location": "37x13->52x23/1324->2305",
+                                                            "location": "1324->2305",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "37x13->37x1361/1324->1360",
+                                                                    "location": "1324->1360",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "37x13->37x1326/1324->1325",
+                                                                            "location": "1324->1325",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "37x14->37x1333/1325->1332",
+                                                                            "location": "1325->1332",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "37x21->37x1334/1332->1333",
+                                                                            "location": "1332->1333",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -772,7 +772,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:param",
-                                                                            "location": "37x22->37x1360/1333->1359",
+                                                                            "location": "1333->1359",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "value": "item inView data.itemsView"
@@ -780,18 +780,18 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "37x48->37x1361/1359->1360",
+                                                                            "location": "1359->1360",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-statement-content",
-                                                                    "location": "37x49->52x13/1360->2295",
+                                                                    "location": "1360->2295",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "37x49->38x1/1360->1362",
+                                                                            "location": "1360->1362",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -799,7 +799,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "38x1->38x1379/1362->1378",
+                                                                            "location": "1362->1378",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -807,25 +807,25 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:block-statement",
-                                                                            "location": "38x17->39x22/1378->1444",
+                                                                            "location": "1378->1444",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "38x17->38x1422/1378->1421",
+                                                                                    "location": "1378->1421",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "38x17->38x1380/1378->1379",
+                                                                                            "location": "1378->1379",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "38x18->38x1382/1379->1381",
+                                                                                            "location": "1379->1381",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "38x20->38x1383/1381->1382",
+                                                                                            "location": "1381->1382",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -833,7 +833,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:param",
-                                                                                            "location": "38x21->38x1421/1382->1420",
+                                                                                            "location": "1382->1420",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "value": "item_index % data.numberOfColumns == 0"
@@ -841,18 +841,18 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "38x59->38x1422/1420->1421",
+                                                                                            "location": "1420->1421",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:block-statement-content",
-                                                                                    "location": "38x60->39x17/1421->1439",
+                                                                                    "location": "1421->1439",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "38x60->39x1/1421->1423",
+                                                                                            "location": "1421->1423",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -860,7 +860,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "39x1->39x1440/1423->1439",
+                                                                                            "location": "1423->1439",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -870,21 +870,21 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "39x17->39x1445/1439->1444",
+                                                                                    "location": "1439->1444",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "39x17->39x1442/1439->1441",
+                                                                                            "location": "1439->1441",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "39x19->39x1444/1441->1443",
+                                                                                            "location": "1441->1443",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "39x21->39x1445/1443->1444",
+                                                                                            "location": "1443->1444",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
@@ -893,7 +893,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "39x22->41x1/1444->1448",
+                                                                            "location": "1444->1448",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 2
@@ -901,7 +901,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "41x1->41x1465/1448->1464",
+                                                                            "location": "1448->1464",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -909,21 +909,21 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-statement",
-                                                                            "location": "41x17->41x1510/1464->1509",
+                                                                            "location": "1464->1509",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "41x17->41x1466/1464->1465",
+                                                                                    "location": "1464->1465",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-id",
-                                                                                    "location": "41x18->41x1470/1465->1469",
+                                                                                    "location": "1465->1469",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "41x22->41x23/1469->1470",
+                                                                                    "location": "1469->1470",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -931,7 +931,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "41x23->41x60/1470->1507",
+                                                                                    "location": "1470->1507",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "renderItem(item, item_info.initIndex)"
@@ -939,14 +939,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "41x60->41x1510/1507->1509",
+                                                                                    "location": "1507->1509",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "41x62->42x1/1509->1511",
+                                                                            "location": "1509->1511",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -954,7 +954,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "42x1->42x1528/1511->1527",
+                                                                            "location": "1511->1527",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -962,25 +962,25 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:block-statement",
-                                                                            "location": "42x17->48x22/1527->2189",
+                                                                            "location": "1527->2189",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "42x17->42x1572/1527->1571",
+                                                                                    "location": "1527->1571",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "42x17->42x1529/1527->1528",
+                                                                                            "location": "1527->1528",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "42x18->42x1531/1528->1530",
+                                                                                            "location": "1528->1530",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "42x20->42x1532/1530->1531",
+                                                                                            "location": "1530->1531",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -988,7 +988,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:param",
-                                                                                            "location": "42x21->42x1571/1531->1570",
+                                                                                            "location": "1531->1570",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "value": "(data.displayOptions.tableMode == true)"
@@ -996,18 +996,18 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "42x60->42x1572/1570->1571",
+                                                                                            "location": "1570->1571",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:block-statement-content",
-                                                                                    "location": "42x61->48x17/1571->2184",
+                                                                                    "location": "1571->2184",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "42x61->43x1/1571->1573",
+                                                                                            "location": "1571->1573",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1015,7 +1015,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "43x1->43x1594/1573->1593",
+                                                                                            "location": "1573->1593",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -1023,21 +1023,21 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:inline-statement",
-                                                                                            "location": "43x21->43x1643/1593->1642",
+                                                                                            "location": "1593->1642",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "43x21->43x1595/1593->1594",
+                                                                                                    "location": "1593->1594",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:at-id",
-                                                                                                    "location": "43x22->43x1598/1594->1597",
+                                                                                                    "location": "1594->1597",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:spaces",
-                                                                                                    "location": "43x25->43x26/1597->1598",
+                                                                                                    "location": "1597->1598",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "size": 1
@@ -1045,7 +1045,7 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "43x26->43x68/1598->1640",
+                                                                                                    "location": "1598->1640",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "checkboxLabelSplit = item.label.split('|')"
@@ -1053,14 +1053,14 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "43x68->43x1643/1640->1642",
+                                                                                                    "location": "1640->1642",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "43x70->44x1/1642->1644",
+                                                                                            "location": "1642->1644",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1068,7 +1068,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "44x1->44x1665/1644->1664",
+                                                                                            "location": "1644->1664",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -1076,26 +1076,26 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:text",
-                                                                                            "location": "44x21->44x1668/1664->1667",
+                                                                                            "location": "1664->1667",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:inline-statement",
-                                                                                            "location": "44x24->44x1750/1667->1749",
+                                                                                            "location": "1667->1749",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "44x24->44x1669/1667->1668",
+                                                                                                    "location": "1667->1668",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:at-id",
-                                                                                                    "location": "44x25->44x1671/1668->1670",
+                                                                                                    "location": "1668->1670",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:spaces",
-                                                                                                    "location": "44x27->44x28/1670->1671",
+                                                                                                    "location": "1670->1671",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "size": 1
@@ -1103,7 +1103,7 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "44x28->44x104/1671->1747",
+                                                                                                    "location": "1671->1747",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1111,23 +1111,23 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "44x104->44x1750/1747->1749",
+                                                                                                    "location": "1747->1749",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:expression",
-                                                                                            "location": "44x106->44x1774/1749->1773",
+                                                                                            "location": "1749->1773",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "44x106->44x1752/1749->1751",
+                                                                                                    "location": "1749->1751",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "44x108->44x1773/1751->1772",
+                                                                                                    "location": "1751->1772",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "checkboxLabelSplit[0]"
@@ -1135,14 +1135,14 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "44x129->44x1774/1772->1773",
+                                                                                                    "location": "1772->1773",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "44x130->45x1/1773->1775",
+                                                                                            "location": "1773->1775",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1150,7 +1150,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "45x1->45x1796/1775->1795",
+                                                                                            "location": "1775->1795",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -1158,26 +1158,26 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:text",
-                                                                                            "location": "45x21->45x1799/1795->1798",
+                                                                                            "location": "1795->1798",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:inline-statement",
-                                                                                            "location": "45x24->45x1881/1798->1880",
+                                                                                            "location": "1798->1880",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "45x24->45x1800/1798->1799",
+                                                                                                    "location": "1798->1799",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:at-id",
-                                                                                                    "location": "45x25->45x1802/1799->1801",
+                                                                                                    "location": "1799->1801",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:spaces",
-                                                                                                    "location": "45x27->45x28/1801->1802",
+                                                                                                    "location": "1801->1802",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "size": 1
@@ -1185,7 +1185,7 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "45x28->45x104/1802->1878",
+                                                                                                    "location": "1802->1878",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1193,23 +1193,23 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "45x104->45x1881/1878->1880",
+                                                                                                    "location": "1878->1880",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:expression",
-                                                                                            "location": "45x106->45x1905/1880->1904",
+                                                                                            "location": "1880->1904",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "45x106->45x1883/1880->1882",
+                                                                                                    "location": "1880->1882",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "45x108->45x1904/1882->1903",
+                                                                                                    "location": "1882->1903",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "checkboxLabelSplit[1]"
@@ -1217,14 +1217,14 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "45x129->45x1905/1903->1904",
+                                                                                                    "location": "1903->1904",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "45x130->46x1/1904->1906",
+                                                                                            "location": "1904->1906",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1232,7 +1232,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "46x1->46x1927/1906->1926",
+                                                                                            "location": "1906->1926",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -1240,26 +1240,26 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:text",
-                                                                                            "location": "46x21->46x1930/1926->1929",
+                                                                                            "location": "1926->1929",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:inline-statement",
-                                                                                            "location": "46x24->46x2012/1929->2011",
+                                                                                            "location": "1929->2011",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "46x24->46x1931/1929->1930",
+                                                                                                    "location": "1929->1930",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:at-id",
-                                                                                                    "location": "46x25->46x1933/1930->1932",
+                                                                                                    "location": "1930->1932",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:spaces",
-                                                                                                    "location": "46x27->46x28/1932->1933",
+                                                                                                    "location": "1932->1933",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "size": 1
@@ -1267,7 +1267,7 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "46x28->46x104/1933->2009",
+                                                                                                    "location": "1933->2009",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1275,23 +1275,23 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "46x104->46x2012/2009->2011",
+                                                                                                    "location": "2009->2011",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:expression",
-                                                                                            "location": "46x106->46x2036/2011->2035",
+                                                                                            "location": "2011->2035",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "46x106->46x2014/2011->2013",
+                                                                                                    "location": "2011->2013",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "46x108->46x2035/2013->2034",
+                                                                                                    "location": "2013->2034",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "checkboxLabelSplit[2]"
@@ -1299,14 +1299,14 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "46x129->46x2036/2034->2035",
+                                                                                                    "location": "2034->2035",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "46x130->47x1/2035->2037",
+                                                                                            "location": "2035->2037",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1314,7 +1314,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "47x1->47x2058/2037->2057",
+                                                                                            "location": "2037->2057",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -1322,26 +1322,26 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:text",
-                                                                                            "location": "47x21->47x2061/2057->2060",
+                                                                                            "location": "2057->2060",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:inline-statement",
-                                                                                            "location": "47x24->47x2143/2060->2142",
+                                                                                            "location": "2060->2142",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "47x24->47x2062/2060->2061",
+                                                                                                    "location": "2060->2061",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:at-id",
-                                                                                                    "location": "47x25->47x2064/2061->2063",
+                                                                                                    "location": "2061->2063",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:spaces",
-                                                                                                    "location": "47x27->47x28/2063->2064",
+                                                                                                    "location": "2063->2064",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "size": 1
@@ -1349,7 +1349,7 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "47x28->47x104/2064->2140",
+                                                                                                    "location": "2064->2140",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "click {fn: \"itemTableClick\", args: {    item : item, itemIdx : item.index }}"
@@ -1357,23 +1357,23 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "47x104->47x2143/2140->2142",
+                                                                                                    "location": "2140->2142",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:expression",
-                                                                                            "location": "47x106->47x2167/2142->2166",
+                                                                                            "location": "2142->2166",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "47x106->47x2145/2142->2144",
+                                                                                                    "location": "2142->2144",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "47x108->47x2166/2144->2165",
+                                                                                                    "location": "2144->2165",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "checkboxLabelSplit[3]"
@@ -1381,14 +1381,14 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "47x129->47x2167/2165->2166",
+                                                                                                    "location": "2165->2166",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "47x130->48x1/2166->2168",
+                                                                                            "location": "2166->2168",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1396,7 +1396,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "48x1->48x2185/2168->2184",
+                                                                                            "location": "2168->2184",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -1406,21 +1406,21 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "48x17->48x2190/2184->2189",
+                                                                                    "location": "2184->2189",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "48x17->48x2187/2184->2186",
+                                                                                            "location": "2184->2186",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "48x19->48x2189/2186->2188",
+                                                                                            "location": "2186->2188",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "48x21->48x2190/2188->2189",
+                                                                                            "location": "2188->2189",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
@@ -1429,7 +1429,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "48x22->50x1/2189->2193",
+                                                                            "location": "2189->2193",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 2
@@ -1437,7 +1437,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "50x1->50x2210/2193->2209",
+                                                                            "location": "2193->2209",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -1445,25 +1445,25 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:block-statement",
-                                                                            "location": "50x17->51x22/2209->2281",
+                                                                            "location": "2209->2281",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "50x17->50x2259/2209->2258",
+                                                                                    "location": "2209->2258",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "50x17->50x2211/2209->2210",
+                                                                                            "location": "2209->2210",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "50x18->50x2213/2210->2212",
+                                                                                            "location": "2210->2212",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "50x20->50x2214/2212->2213",
+                                                                                            "location": "2212->2213",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1471,7 +1471,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:param",
-                                                                                            "location": "50x21->50x2258/2213->2257",
+                                                                                            "location": "2213->2257",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "value": "(item_index + 1) % data.numberOfColumns == 0"
@@ -1479,18 +1479,18 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "50x65->50x2259/2257->2258",
+                                                                                            "location": "2257->2258",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:block-statement-content",
-                                                                                    "location": "50x66->51x17/2258->2276",
+                                                                                    "location": "2258->2276",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "50x66->51x1/2258->2260",
+                                                                                            "location": "2258->2260",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -1498,7 +1498,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "51x1->51x2277/2260->2276",
+                                                                                            "location": "2260->2276",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -1508,21 +1508,21 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "51x17->51x2282/2276->2281",
+                                                                                    "location": "2276->2281",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "51x17->51x2279/2276->2278",
+                                                                                            "location": "2276->2278",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "51x19->51x2281/2278->2280",
+                                                                                            "location": "2278->2280",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "51x21->51x2282/2280->2281",
+                                                                                            "location": "2280->2281",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
@@ -1531,7 +1531,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "51x22->52x1/2281->2283",
+                                                                            "location": "2281->2283",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -1539,7 +1539,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "52x1->52x2296/2283->2295",
+                                                                            "location": "2283->2295",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -1549,21 +1549,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "52x13->52x2306/2295->2305",
+                                                                    "location": "2295->2305",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "52x13->52x2298/2295->2297",
+                                                                            "location": "2295->2297",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "52x15->52x2305/2297->2304",
+                                                                            "location": "2297->2304",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "52x22->52x2306/2304->2305",
+                                                                            "location": "2304->2305",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -1572,7 +1572,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "52x23->53x1/2305->2307",
+                                                            "location": "2305->2307",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -1580,7 +1580,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "53x1->53x2316/2307->2315",
+                                                            "location": "2307->2315",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -1588,21 +1588,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "53x9->53x2377/2315->2376",
+                                                            "location": "2315->2376",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "53x9->53x2317/2315->2316",
+                                                                    "location": "2315->2316",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "53x10->53x2323/2316->2322",
+                                                                    "location": "2316->2322",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "53x16->53x17/2322->2323",
+                                                                    "location": "2322->2323",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1610,7 +1610,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "53x17->53x68/2323->2374",
+                                                                    "location": "2323->2374",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "(data.displayOptions.flowOrientation == 'vertical')"
@@ -1618,14 +1618,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "53x68->53x2377/2374->2376",
+                                                                    "location": "2374->2376",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "53x70->54x1/2376->2378",
+                                                            "location": "2376->2378",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -1633,7 +1633,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "54x1->54x2391/2378->2390",
+                                                            "location": "2378->2390",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -1641,21 +1641,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "54x13->54x2428/2390->2427",
+                                                            "location": "2390->2427",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "54x13->54x2392/2390->2391",
+                                                                    "location": "2390->2391",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "54x14->54x2395/2391->2394",
+                                                                    "location": "2391->2394",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "54x17->54x18/2394->2395",
+                                                                    "location": "2394->2395",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1663,7 +1663,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "54x18->54x47/2395->2424",
+                                                                    "location": "2395->2424",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "lineCount = data.numberOfRows"
@@ -1671,7 +1671,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "54x47->54x48/2424->2425",
+                                                                    "location": "2424->2425",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1679,14 +1679,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "54x48->54x2428/2425->2427",
+                                                                    "location": "2425->2427",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "54x50->55x1/2427->2429",
+                                                            "location": "2427->2429",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -1694,7 +1694,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "55x1->55x2442/2429->2441",
+                                                            "location": "2429->2441",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -1702,21 +1702,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "55x13->55x2484/2441->2483",
+                                                            "location": "2441->2483",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "55x13->55x2443/2441->2442",
+                                                                    "location": "2441->2442",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "55x14->55x2446/2442->2445",
+                                                                    "location": "2442->2445",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "55x17->55x18/2445->2446",
+                                                                    "location": "2445->2446",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1724,7 +1724,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "55x18->55x52/2446->2480",
+                                                                    "location": "2446->2480",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "columnCount = data.numberOfColumns"
@@ -1732,7 +1732,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "55x52->55x53/2480->2481",
+                                                                    "location": "2480->2481",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1740,14 +1740,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "55x53->55x2484/2481->2483",
+                                                                    "location": "2481->2483",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "55x55->56x1/2483->2485",
+                                                            "location": "2483->2485",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -1755,7 +1755,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "56x1->56x2498/2485->2497",
+                                                            "location": "2485->2497",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -1763,21 +1763,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "56x13->56x2521/2497->2520",
+                                                            "location": "2497->2520",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "56x13->56x2499/2497->2498",
+                                                                    "location": "2497->2498",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "56x14->56x2502/2498->2501",
+                                                                    "location": "2498->2501",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "56x17->56x18/2501->2502",
+                                                                    "location": "2501->2502",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1785,7 +1785,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "56x18->56x33/2502->2517",
+                                                                    "location": "2502->2517",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "outputCount = 0"
@@ -1793,7 +1793,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "56x33->56x34/2517->2518",
+                                                                    "location": "2517->2518",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1801,14 +1801,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "56x34->56x2521/2518->2520",
+                                                                    "location": "2518->2520",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "56x36->57x1/2520->2522",
+                                                            "location": "2520->2522",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -1816,7 +1816,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "57x1->57x2535/2522->2534",
+                                                            "location": "2522->2534",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -1824,21 +1824,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "57x13->57x2557/2534->2556",
+                                                            "location": "2534->2556",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "57x13->57x2536/2534->2535",
+                                                                    "location": "2534->2535",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "57x14->57x2539/2535->2538",
+                                                                    "location": "2535->2538",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "57x17->57x18/2538->2539",
+                                                                    "location": "2538->2539",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1846,7 +1846,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "57x18->57x32/2539->2553",
+                                                                    "location": "2539->2553",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "outputRows = 1"
@@ -1854,7 +1854,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "57x32->57x33/2553->2554",
+                                                                    "location": "2553->2554",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -1862,14 +1862,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "57x33->57x2557/2554->2556",
+                                                                    "location": "2554->2556",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "57x35->58x1/2556->2558",
+                                                            "location": "2556->2558",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -1877,7 +1877,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "58x1->58x2571/2558->2570",
+                                                            "location": "2558->2570",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -1885,25 +1885,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-statement",
-                                                            "location": "58x13->69x19/2570->3147",
+                                                            "location": "2570->3147",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "58x13->58x2607/2570->2606",
+                                                                    "location": "2570->2606",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "58x13->58x2572/2570->2571",
+                                                                            "location": "2570->2571",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "58x14->58x2575/2571->2574",
+                                                                            "location": "2571->2574",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "58x17->58x2576/2574->2575",
+                                                                            "location": "2574->2575",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -1911,7 +1911,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:param",
-                                                                            "location": "58x18->58x2606/2575->2605",
+                                                                            "location": "2575->2605",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "value": "var i = 0 ; i  lineCount ; i++"
@@ -1919,18 +1919,18 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "58x48->58x2607/2605->2606",
+                                                                            "location": "2605->2606",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-statement-content",
-                                                                    "location": "58x49->69x13/2606->3141",
+                                                                    "location": "2606->3141",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "58x49->59x1/2606->2608",
+                                                                            "location": "2606->2608",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -1938,7 +1938,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "59x1->59x2625/2608->2624",
+                                                                            "location": "2608->2624",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -1946,21 +1946,21 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-statement",
-                                                                            "location": "59x17->59x2649/2624->2648",
+                                                                            "location": "2624->2648",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "59x17->59x2626/2624->2625",
+                                                                                    "location": "2624->2625",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-id",
-                                                                                    "location": "59x18->59x2629/2625->2628",
+                                                                                    "location": "2625->2628",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "59x21->59x22/2628->2629",
+                                                                                    "location": "2628->2629",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -1968,7 +1968,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "59x22->59x38/2629->2645",
+                                                                                    "location": "2629->2645",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "lastColCount = 0"
@@ -1976,7 +1976,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "59x38->59x39/2645->2646",
+                                                                                    "location": "2645->2646",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -1984,14 +1984,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "59x39->59x2649/2646->2648",
+                                                                                    "location": "2646->2648",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "59x41->60x1/2648->2650",
+                                                                            "location": "2648->2650",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -1999,7 +1999,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "60x1->60x2667/2650->2666",
+                                                                            "location": "2650->2666",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -2007,25 +2007,25 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:block-statement",
-                                                                            "location": "60x17->67x23/2666->3075",
+                                                                            "location": "2666->3075",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "60x17->60x2706/2666->2705",
+                                                                                    "location": "2666->2705",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "60x17->60x2668/2666->2667",
+                                                                                            "location": "2666->2667",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "60x18->60x2671/2667->2670",
+                                                                                            "location": "2667->2670",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "60x21->60x2672/2670->2671",
+                                                                                            "location": "2670->2671",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2033,7 +2033,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:param",
-                                                                                            "location": "60x22->60x2704/2671->2703",
+                                                                                            "location": "2671->2703",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "value": "var j = 0 ; j  columnCount ; j++"
@@ -2041,7 +2041,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "60x54->60x2705/2703->2704",
+                                                                                            "location": "2703->2704",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2049,18 +2049,18 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "60x55->60x2706/2704->2705",
+                                                                                            "location": "2704->2705",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:block-statement-content",
-                                                                                    "location": "60x56->67x17/2705->3069",
+                                                                                    "location": "2705->3069",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "60x56->61x1/2705->2707",
+                                                                                            "location": "2705->2707",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2068,7 +2068,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "61x1->61x2728/2707->2727",
+                                                                                            "location": "2707->2727",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -2076,21 +2076,21 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:inline-statement",
-                                                                                            "location": "61x21->61x2762/2727->2761",
+                                                                                            "location": "2727->2761",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "61x21->61x2729/2727->2728",
+                                                                                                    "location": "2727->2728",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:at-id",
-                                                                                                    "location": "61x22->61x2732/2728->2731",
+                                                                                                    "location": "2728->2731",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:spaces",
-                                                                                                    "location": "61x25->61x26/2731->2732",
+                                                                                                    "location": "2731->2732",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "size": 1
@@ -2098,7 +2098,7 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "61x26->61x53/2732->2759",
+                                                                                                    "location": "2732->2759",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "itemIndex = (j*lineCount)+i"
@@ -2106,14 +2106,14 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "61x53->61x2762/2759->2761",
+                                                                                                    "location": "2759->2761",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "61x55->62x1/2761->2763",
+                                                                                            "location": "2761->2763",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2121,7 +2121,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "62x1->62x2784/2763->2783",
+                                                                                            "location": "2763->2783",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -2129,25 +2129,25 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:block-statement",
-                                                                                            "location": "62x21->65x26/2783->2993",
+                                                                                            "location": "2783->2993",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "62x21->62x2829/2783->2828",
+                                                                                                    "location": "2783->2828",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "62x21->62x2785/2783->2784",
+                                                                                                            "location": "2783->2784",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "62x22->62x2787/2784->2786",
+                                                                                                            "location": "2784->2786",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "62x24->62x2788/2786->2787",
+                                                                                                            "location": "2786->2787",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -2155,7 +2155,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:param",
-                                                                                                            "location": "62x25->62x2828/2787->2827",
+                                                                                                            "location": "2787->2827",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "value": "(itemIndex  data.itemsView.items.length)"
@@ -2163,18 +2163,18 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "62x65->62x2829/2827->2828",
+                                                                                                            "location": "2827->2828",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:block-statement-content",
-                                                                                                    "location": "62x66->65x21/2828->2988",
+                                                                                                    "location": "2828->2988",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "62x66->63x1/2828->2830",
+                                                                                                            "location": "2828->2830",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -2182,7 +2182,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "63x1->63x2855/2830->2854",
+                                                                                                            "location": "2830->2854",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 24
@@ -2190,21 +2190,21 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:inline-statement",
-                                                                                                            "location": "63x25->63x2906/2854->2905",
+                                                                                                            "location": "2854->2905",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "63x25->63x2856/2854->2855",
+                                                                                                                    "location": "2854->2855",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:at-id",
-                                                                                                                    "location": "63x26->63x2859/2855->2858",
+                                                                                                                    "location": "2855->2858",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:spaces",
-                                                                                                                    "location": "63x29->63x30/2858->2859",
+                                                                                                                    "location": "2858->2859",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "size": 1
@@ -2212,7 +2212,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:param",
-                                                                                                                    "location": "63x30->63x74/2859->2903",
+                                                                                                                    "location": "2859->2903",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "value": "item = data.itemsView.items[itemIndex].value"
@@ -2220,14 +2220,14 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "63x74->63x2906/2903->2905",
+                                                                                                                    "location": "2903->2905",
                                                                                                                     "children": []
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "63x76->64x1/2905->2907",
+                                                                                                            "location": "2905->2907",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -2235,7 +2235,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "64x1->64x2932/2907->2931",
+                                                                                                            "location": "2907->2931",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 24
@@ -2243,21 +2243,21 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:inline-statement",
-                                                                                                            "location": "64x25->64x2967/2931->2966",
+                                                                                                            "location": "2931->2966",
                                                                                                             "children": [
                                                                                                                 {
                                                                                                                     "type": "at-html:opening",
-                                                                                                                    "location": "64x25->64x2933/2931->2932",
+                                                                                                                    "location": "2931->2932",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:at-id",
-                                                                                                                    "location": "64x26->64x2937/2932->2936",
+                                                                                                                    "location": "2932->2936",
                                                                                                                     "children": []
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:spaces",
-                                                                                                                    "location": "64x30->64x31/2936->2937",
+                                                                                                                    "location": "2936->2937",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "size": 1
@@ -2265,7 +2265,7 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:param",
-                                                                                                                    "location": "64x31->64x58/2937->2964",
+                                                                                                                    "location": "2937->2964",
                                                                                                                     "children": [],
                                                                                                                     "properties": {
                                                                                                                         "value": "renderItem(item, itemIndex)"
@@ -2273,14 +2273,14 @@
                                                                                                                 },
                                                                                                                 {
                                                                                                                     "type": "at-html:closing",
-                                                                                                                    "location": "64x58->64x2967/2964->2966",
+                                                                                                                    "location": "2964->2966",
                                                                                                                     "children": []
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:eols",
-                                                                                                            "location": "64x60->65x1/2966->2968",
+                                                                                                            "location": "2966->2968",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 1
@@ -2288,7 +2288,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:spaces",
-                                                                                                            "location": "65x1->65x2989/2968->2988",
+                                                                                                            "location": "2968->2988",
                                                                                                             "children": [],
                                                                                                             "properties": {
                                                                                                                 "size": 20
@@ -2298,21 +2298,21 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "65x21->65x2994/2988->2993",
+                                                                                                    "location": "2988->2993",
                                                                                                     "children": [
                                                                                                         {
                                                                                                             "type": "at-html:opening",
-                                                                                                            "location": "65x21->65x2991/2988->2990",
+                                                                                                            "location": "2988->2990",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:at-id",
-                                                                                                            "location": "65x23->65x2993/2990->2992",
+                                                                                                            "location": "2990->2992",
                                                                                                             "children": []
                                                                                                         },
                                                                                                         {
                                                                                                             "type": "at-html:closing",
-                                                                                                            "location": "65x25->65x2994/2992->2993",
+                                                                                                            "location": "2992->2993",
                                                                                                             "children": []
                                                                                                         }
                                                                                                     ]
@@ -2321,7 +2321,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "65x26->66x1/2993->2995",
+                                                                                            "location": "2993->2995",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2329,7 +2329,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "66x1->66x3016/2995->3015",
+                                                                                            "location": "2995->3015",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 20
@@ -2337,21 +2337,21 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:inline-statement",
-                                                                                            "location": "66x21->66x3052/3015->3051",
+                                                                                            "location": "3015->3051",
                                                                                             "children": [
                                                                                                 {
                                                                                                     "type": "at-html:opening",
-                                                                                                    "location": "66x21->66x3017/3015->3016",
+                                                                                                    "location": "3015->3016",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:at-id",
-                                                                                                    "location": "66x22->66x3020/3016->3019",
+                                                                                                    "location": "3016->3019",
                                                                                                     "children": []
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:spaces",
-                                                                                                    "location": "66x25->66x26/3019->3020",
+                                                                                                    "location": "3019->3020",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "size": 1
@@ -2359,7 +2359,7 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:param",
-                                                                                                    "location": "66x26->66x55/3020->3049",
+                                                                                                    "location": "3020->3049",
                                                                                                     "children": [],
                                                                                                     "properties": {
                                                                                                         "value": "outputCount = outputCount + 1"
@@ -2367,14 +2367,14 @@
                                                                                                 },
                                                                                                 {
                                                                                                     "type": "at-html:closing",
-                                                                                                    "location": "66x55->66x3052/3049->3051",
+                                                                                                    "location": "3049->3051",
                                                                                                     "children": []
                                                                                                 }
                                                                                             ]
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:eols",
-                                                                                            "location": "66x57->67x1/3051->3053",
+                                                                                            "location": "3051->3053",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 1
@@ -2382,7 +2382,7 @@
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:spaces",
-                                                                                            "location": "67x1->67x3070/3053->3069",
+                                                                                            "location": "3053->3069",
                                                                                             "children": [],
                                                                                             "properties": {
                                                                                                 "size": 16
@@ -2392,21 +2392,21 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "67x17->67x3076/3069->3075",
+                                                                                    "location": "3069->3075",
                                                                                     "children": [
                                                                                         {
                                                                                             "type": "at-html:opening",
-                                                                                            "location": "67x17->67x3072/3069->3071",
+                                                                                            "location": "3069->3071",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:at-id",
-                                                                                            "location": "67x19->67x3075/3071->3074",
+                                                                                            "location": "3071->3074",
                                                                                             "children": []
                                                                                         },
                                                                                         {
                                                                                             "type": "at-html:closing",
-                                                                                            "location": "67x22->67x3076/3074->3075",
+                                                                                            "location": "3074->3075",
                                                                                             "children": []
                                                                                         }
                                                                                     ]
@@ -2415,7 +2415,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "67x23->68x1/3075->3077",
+                                                                            "location": "3075->3077",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -2423,7 +2423,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "68x1->68x3094/3077->3093",
+                                                                            "location": "3077->3093",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -2431,21 +2431,21 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-statement",
-                                                                            "location": "68x17->68x3128/3093->3127",
+                                                                            "location": "3093->3127",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "68x17->68x3095/3093->3094",
+                                                                                    "location": "3093->3094",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-id",
-                                                                                    "location": "68x18->68x3098/3094->3097",
+                                                                                    "location": "3094->3097",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "68x21->68x22/3097->3098",
+                                                                                    "location": "3097->3098",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -2453,7 +2453,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "68x22->68x49/3098->3125",
+                                                                                    "location": "3098->3125",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "outputRows = outputRows + 1"
@@ -2461,14 +2461,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "68x49->68x3128/3125->3127",
+                                                                                    "location": "3125->3127",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "68x51->69x1/3127->3129",
+                                                                            "location": "3127->3129",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -2476,7 +2476,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "69x1->69x3142/3129->3141",
+                                                                            "location": "3129->3141",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -2486,21 +2486,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "69x13->69x3148/3141->3147",
+                                                                    "location": "3141->3147",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "69x13->69x3144/3141->3143",
+                                                                            "location": "3141->3143",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "69x15->69x3147/3143->3146",
+                                                                            "location": "3143->3146",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "69x18->69x3148/3146->3147",
+                                                                            "location": "3146->3147",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -2509,7 +2509,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "69x19->70x1/3147->3149",
+                                                            "location": "3147->3149",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2517,7 +2517,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "70x1->70x3158/3149->3157",
+                                                            "location": "3149->3157",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -2525,28 +2525,28 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "70x9->70x3165/3157->3164",
+                                                            "location": "3157->3164",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "70x9->70x3159/3157->3158",
+                                                                    "location": "3157->3158",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "70x10->70x3163/3158->3162",
+                                                                    "location": "3158->3162",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "70x14->70x3165/3162->3164",
+                                                                    "location": "3162->3164",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "70x16->71x1/3164->3166",
+                                                            "location": "3164->3166",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2554,7 +2554,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "71x1->71x3179/3166->3178",
+                                                            "location": "3166->3178",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -2562,25 +2562,25 @@
                                                         },
                                                         {
                                                             "type": "at-html:block-statement",
-                                                            "location": "71x13->73x23/3178->3301",
+                                                            "location": "3178->3301",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "71x13->71x3215/3178->3214",
+                                                                    "location": "3178->3214",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "71x13->71x3180/3178->3179",
+                                                                            "location": "3178->3179",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "71x14->71x3187/3179->3186",
+                                                                            "location": "3179->3186",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "71x21->71x3188/3186->3187",
+                                                                            "location": "3186->3187",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -2588,7 +2588,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:param",
-                                                                            "location": "71x22->71x3214/3187->3213",
+                                                                            "location": "3187->3213",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "value": "item inView data.itemsView"
@@ -2596,18 +2596,18 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "71x48->71x3215/3213->3214",
+                                                                            "location": "3213->3214",
                                                                             "children": []
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "type": "at-html:block-statement-content",
-                                                                    "location": "71x49->73x13/3214->3291",
+                                                                    "location": "3214->3291",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "71x49->72x1/3214->3216",
+                                                                            "location": "3214->3216",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -2615,7 +2615,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "72x1->72x3233/3216->3232",
+                                                                            "location": "3216->3232",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 16
@@ -2623,21 +2623,21 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:inline-statement",
-                                                                            "location": "72x17->72x3278/3232->3277",
+                                                                            "location": "3232->3277",
                                                                             "children": [
                                                                                 {
                                                                                     "type": "at-html:opening",
-                                                                                    "location": "72x17->72x3234/3232->3233",
+                                                                                    "location": "3232->3233",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:at-id",
-                                                                                    "location": "72x18->72x3238/3233->3237",
+                                                                                    "location": "3233->3237",
                                                                                     "children": []
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:spaces",
-                                                                                    "location": "72x22->72x23/3237->3238",
+                                                                                    "location": "3237->3238",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "size": 1
@@ -2645,7 +2645,7 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:param",
-                                                                                    "location": "72x23->72x60/3238->3275",
+                                                                                    "location": "3238->3275",
                                                                                     "children": [],
                                                                                     "properties": {
                                                                                         "value": "renderItem(item, item_info.initIndex)"
@@ -2653,14 +2653,14 @@
                                                                                 },
                                                                                 {
                                                                                     "type": "at-html:closing",
-                                                                                    "location": "72x60->72x3278/3275->3277",
+                                                                                    "location": "3275->3277",
                                                                                     "children": []
                                                                                 }
                                                                             ]
                                                                         },
                                                                         {
                                                                             "type": "at-html:eols",
-                                                                            "location": "72x62->73x1/3277->3279",
+                                                                            "location": "3277->3279",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 1
@@ -2668,7 +2668,7 @@
                                                                         },
                                                                         {
                                                                             "type": "at-html:spaces",
-                                                                            "location": "73x1->73x3292/3279->3291",
+                                                                            "location": "3279->3291",
                                                                             "children": [],
                                                                             "properties": {
                                                                                 "size": 12
@@ -2678,21 +2678,21 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "73x13->73x3302/3291->3301",
+                                                                    "location": "3291->3301",
                                                                     "children": [
                                                                         {
                                                                             "type": "at-html:opening",
-                                                                            "location": "73x13->73x3294/3291->3293",
+                                                                            "location": "3291->3293",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:at-id",
-                                                                            "location": "73x15->73x3301/3293->3300",
+                                                                            "location": "3293->3300",
                                                                             "children": []
                                                                         },
                                                                         {
                                                                             "type": "at-html:closing",
-                                                                            "location": "73x22->73x3302/3300->3301",
+                                                                            "location": "3300->3301",
                                                                             "children": []
                                                                         }
                                                                     ]
@@ -2701,7 +2701,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "73x23->74x1/3301->3303",
+                                                            "location": "3301->3303",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2709,7 +2709,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "74x1->74x3312/3303->3311",
+                                                            "location": "3303->3311",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -2719,21 +2719,21 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "74x9->74x3317/3311->3316",
+                                                    "location": "3311->3316",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "74x9->74x3314/3311->3313",
+                                                            "location": "3311->3313",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "74x11->74x3316/3313->3315",
+                                                            "location": "3313->3315",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "74x13->74x3317/3315->3316",
+                                                            "location": "3315->3316",
                                                             "children": []
                                                         }
                                                     ]
@@ -2742,7 +2742,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "74x14->75x1/3316->3318",
+                                            "location": "3316->3318",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -2750,7 +2750,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "75x1->75x3323/3318->3322",
+                                            "location": "3318->3322",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -2760,21 +2760,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "75x5->75x3331/3322->3330",
+                                    "location": "3322->3330",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "75x5->75x3325/3322->3324",
+                                            "location": "3322->3324",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "75x7->75x3330/3324->3329",
+                                            "location": "3324->3329",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "75x12->75x3331/3329->3330",
+                                            "location": "3329->3330",
                                             "children": []
                                         }
                                     ]
@@ -2783,7 +2783,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "75x13->77x1/3330->3334",
+                            "location": "3330->3334",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -2791,7 +2791,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "77x1->77x3339/3334->3338",
+                            "location": "3334->3338",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -2799,25 +2799,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "77x5->113x13/3338->4496",
+                            "location": "3338->4496",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "77x5->77x3363/3338->3362",
+                                    "location": "3338->3362",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "77x5->77x3340/3338->3339",
+                                            "location": "3338->3339",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "77x6->77x3345/3339->3344",
+                                            "location": "3339->3344",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "77x11->77x3346/3344->3345",
+                                            "location": "3344->3345",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -2825,7 +2825,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "77x12->77x3362/3345->3361",
+                                            "location": "3345->3361",
                                             "children": [],
                                             "properties": {
                                                 "value": "renderItem(item)"
@@ -2833,18 +2833,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "77x28->77x3363/3361->3362",
+                                            "location": "3361->3362",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "77x29->113x5/3362->4488",
+                                    "location": "3362->4488",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "77x29->79x1/3362->3366",
+                                            "location": "3362->3366",
                                             "children": [],
                                             "properties": {
                                                 "size": 2
@@ -2852,7 +2852,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "79x1->79x3375/3366->3374",
+                                            "location": "3366->3374",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -2860,21 +2860,21 @@
                                         },
                                         {
                                             "type": "at-html:inline-statement",
-                                            "location": "79x9->79x3405/3374->3404",
+                                            "location": "3374->3404",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "79x9->79x3376/3374->3375",
+                                                    "location": "3374->3375",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-id",
-                                                    "location": "79x10->79x3379/3375->3378",
+                                                    "location": "3375->3378",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:spaces",
-                                                    "location": "79x13->79x14/3378->3379",
+                                                    "location": "3378->3379",
                                                     "children": [],
                                                     "properties": {
                                                         "size": 1
@@ -2882,7 +2882,7 @@
                                                 },
                                                 {
                                                     "type": "at-html:param",
-                                                    "location": "79x14->79x37/3379->3402",
+                                                    "location": "3379->3402",
                                                     "children": [],
                                                     "properties": {
                                                         "value": "checkboxLabel = \"Error\""
@@ -2890,14 +2890,14 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "79x37->79x3405/3402->3404",
+                                                    "location": "3402->3404",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "79x39->80x1/3404->3406",
+                                            "location": "3404->3406",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -2905,7 +2905,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "80x1->80x3415/3406->3414",
+                                            "location": "3406->3414",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -2913,25 +2913,25 @@
                                         },
                                         {
                                             "type": "at-html:block-statement",
-                                            "location": "80x9->86x14/3414->3773",
+                                            "location": "3414->3773",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "80x9->80x3463/3414->3462",
+                                                    "location": "3414->3462",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "80x9->80x3416/3414->3415",
+                                                            "location": "3414->3415",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "80x10->80x3418/3415->3417",
+                                                            "location": "3415->3417",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "80x12->80x3419/3417->3418",
+                                                            "location": "3417->3418",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2939,7 +2939,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "80x13->80x3462/3418->3461",
+                                                            "location": "3418->3461",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "(data.displayOptions.listDisplay == 'code')"
@@ -2947,18 +2947,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "80x56->80x3463/3461->3462",
+                                                            "location": "3461->3462",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "80x57->86x9/3462->3768",
+                                                    "location": "3462->3768",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "80x57->81x1/3462->3464",
+                                                            "location": "3462->3464",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -2966,7 +2966,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "81x1->81x3477/3464->3476",
+                                                            "location": "3464->3476",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -2974,21 +2974,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "81x13->81x3510/3476->3509",
+                                                            "location": "3476->3509",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "81x13->81x3478/3476->3477",
+                                                                    "location": "3476->3477",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "81x14->81x3481/3477->3480",
+                                                                    "location": "3477->3480",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "81x17->81x18/3480->3481",
+                                                                    "location": "3480->3481",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -2996,7 +2996,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "81x18->81x44/3481->3507",
+                                                                    "location": "3481->3507",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = item.value"
@@ -3004,14 +3004,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "81x44->81x3510/3507->3509",
+                                                                    "location": "3507->3509",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "81x46->82x1/3509->3511",
+                                                            "location": "3509->3511",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3019,7 +3019,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "82x1->82x3520/3511->3519",
+                                                            "location": "3511->3519",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3027,21 +3027,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "82x9->82x3574/3519->3573",
+                                                            "location": "3519->3573",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "82x9->82x3521/3519->3520",
+                                                                    "location": "3519->3520",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "82x10->82x3527/3520->3526",
+                                                                    "location": "3520->3526",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "82x16->82x17/3526->3527",
+                                                                    "location": "3526->3527",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3049,7 +3049,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "82x17->82x61/3527->3571",
+                                                                    "location": "3527->3571",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "(data.displayOptions.listDisplay == 'label')"
@@ -3057,14 +3057,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "82x61->82x3574/3571->3573",
+                                                                    "location": "3571->3573",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "82x63->83x1/3573->3575",
+                                                            "location": "3573->3575",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3072,7 +3072,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "83x1->83x3588/3575->3587",
+                                                            "location": "3575->3587",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -3080,21 +3080,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "83x13->83x3621/3587->3620",
+                                                            "location": "3587->3620",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "83x13->83x3589/3587->3588",
+                                                                    "location": "3587->3588",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "83x14->83x3592/3588->3591",
+                                                                    "location": "3588->3591",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "83x17->83x18/3591->3592",
+                                                                    "location": "3591->3592",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3102,7 +3102,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "83x18->83x44/3592->3618",
+                                                                    "location": "3592->3618",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = item.label"
@@ -3110,14 +3110,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "83x44->83x3621/3618->3620",
+                                                                    "location": "3618->3620",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "83x46->84x1/3620->3622",
+                                                            "location": "3620->3622",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3125,7 +3125,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "84x1->84x3631/3622->3630",
+                                                            "location": "3622->3630",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3133,21 +3133,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "84x9->84x3684/3630->3683",
+                                                            "location": "3630->3683",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "84x9->84x3632/3630->3631",
+                                                                    "location": "3630->3631",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "84x10->84x3638/3631->3637",
+                                                                    "location": "3631->3637",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "84x16->84x17/3637->3638",
+                                                                    "location": "3637->3638",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3155,7 +3155,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "84x17->84x60/3638->3681",
+                                                                    "location": "3638->3681",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "(data.displayOptions.listDisplay == 'both')"
@@ -3163,14 +3163,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "84x60->84x3684/3681->3683",
+                                                                    "location": "3681->3683",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "84x62->85x1/3683->3685",
+                                                            "location": "3683->3685",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3178,7 +3178,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "85x1->85x3698/3685->3697",
+                                                            "location": "3685->3697",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -3186,21 +3186,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "85x13->85x3759/3697->3758",
+                                                            "location": "3697->3758",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "85x13->85x3699/3697->3698",
+                                                                    "location": "3697->3698",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "85x14->85x3702/3698->3701",
+                                                                    "location": "3698->3701",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "85x17->85x18/3701->3702",
+                                                                    "location": "3701->3702",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3208,7 +3208,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "85x18->85x71/3702->3755",
+                                                                    "location": "3702->3755",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = item.label + \" (\" + item.value + \") \""
@@ -3216,7 +3216,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "85x71->85x72/3755->3756",
+                                                                    "location": "3755->3756",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3224,14 +3224,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "85x72->85x3759/3756->3758",
+                                                                    "location": "3756->3758",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "85x74->86x1/3758->3760",
+                                                            "location": "3758->3760",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3239,7 +3239,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "86x1->86x3769/3760->3768",
+                                                            "location": "3760->3768",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3249,21 +3249,21 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "86x9->86x3774/3768->3773",
+                                                    "location": "3768->3773",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "86x9->86x3771/3768->3770",
+                                                            "location": "3768->3770",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "86x11->86x3773/3770->3772",
+                                                            "location": "3770->3772",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "86x13->86x3774/3772->3773",
+                                                            "location": "3772->3773",
                                                             "children": []
                                                         }
                                                     ]
@@ -3272,7 +3272,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "86x14->87x1/3773->3775",
+                                            "location": "3773->3775",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3280,7 +3280,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "87x1->87x3784/3775->3783",
+                                            "location": "3775->3783",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -3288,25 +3288,25 @@
                                         },
                                         {
                                             "type": "at-html:block-statement",
-                                            "location": "87x9->89x14/3783->3881",
+                                            "location": "3783->3881",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "87x9->87x3828/3783->3827",
+                                                    "location": "3783->3827",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "87x9->87x3785/3783->3784",
+                                                            "location": "3783->3784",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "87x10->87x3787/3784->3786",
+                                                            "location": "3784->3786",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "87x12->87x3788/3786->3787",
+                                                            "location": "3786->3787",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3314,7 +3314,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:param",
-                                                            "location": "87x13->87x3827/3787->3826",
+                                                            "location": "3787->3826",
                                                             "children": [],
                                                             "properties": {
                                                                 "value": "(data.displayOptions.tableMode == true)"
@@ -3322,18 +3322,18 @@
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "87x52->87x3828/3826->3827",
+                                                            "location": "3826->3827",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:block-statement-content",
-                                                    "location": "87x53->89x9/3827->3876",
+                                                    "location": "3827->3876",
                                                     "children": [
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "87x53->88x1/3827->3829",
+                                                            "location": "3827->3829",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3341,7 +3341,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "88x1->88x3842/3829->3841",
+                                                            "location": "3829->3841",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 12
@@ -3349,21 +3349,21 @@
                                                         },
                                                         {
                                                             "type": "at-html:inline-statement",
-                                                            "location": "88x13->88x3867/3841->3866",
+                                                            "location": "3841->3866",
                                                             "children": [
                                                                 {
                                                                     "type": "at-html:opening",
-                                                                    "location": "88x13->88x3843/3841->3842",
+                                                                    "location": "3841->3842",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:at-id",
-                                                                    "location": "88x14->88x3846/3842->3845",
+                                                                    "location": "3842->3845",
                                                                     "children": []
                                                                 },
                                                                 {
                                                                     "type": "at-html:spaces",
-                                                                    "location": "88x17->88x18/3845->3846",
+                                                                    "location": "3845->3846",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "size": 1
@@ -3371,7 +3371,7 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:param",
-                                                                    "location": "88x18->88x36/3846->3864",
+                                                                    "location": "3846->3864",
                                                                     "children": [],
                                                                     "properties": {
                                                                         "value": "checkboxLabel = \"\""
@@ -3379,14 +3379,14 @@
                                                                 },
                                                                 {
                                                                     "type": "at-html:closing",
-                                                                    "location": "88x36->88x3867/3864->3866",
+                                                                    "location": "3864->3866",
                                                                     "children": []
                                                                 }
                                                             ]
                                                         },
                                                         {
                                                             "type": "at-html:eols",
-                                                            "location": "88x38->89x1/3866->3868",
+                                                            "location": "3866->3868",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 1
@@ -3394,7 +3394,7 @@
                                                         },
                                                         {
                                                             "type": "at-html:spaces",
-                                                            "location": "89x1->89x3877/3868->3876",
+                                                            "location": "3868->3876",
                                                             "children": [],
                                                             "properties": {
                                                                 "size": 8
@@ -3404,21 +3404,21 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "89x9->89x3882/3876->3881",
+                                                    "location": "3876->3881",
                                                     "children": [
                                                         {
                                                             "type": "at-html:opening",
-                                                            "location": "89x9->89x3879/3876->3878",
+                                                            "location": "3876->3878",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-id",
-                                                            "location": "89x11->89x3881/3878->3880",
+                                                            "location": "3878->3880",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:closing",
-                                                            "location": "89x13->89x3882/3880->3881",
+                                                            "location": "3880->3881",
                                                             "children": []
                                                         }
                                                     ]
@@ -3427,7 +3427,7 @@
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "89x14->92x1/3881->3887",
+                                            "location": "3881->3887",
                                             "children": [],
                                             "properties": {
                                                 "size": 3
@@ -3435,7 +3435,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "92x1->92x3896/3887->3895",
+                                            "location": "3887->3895",
                                             "children": [],
                                             "properties": {
                                                 "size": 8
@@ -3443,32 +3443,32 @@
                                         },
                                         {
                                             "type": "at-html:inline-widget",
-                                            "location": "92x9->111x12/3895->4480",
+                                            "location": "3895->4480",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "92x9->92x3897/3895->3896",
+                                                    "location": "3895->3896",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-widget-id",
-                                                    "location": "92x10->92x3911/3896->3910",
+                                                    "location": "3896->3910",
                                                     "children": [
                                                         {
                                                             "type": "at-html:at-widget-library",
-                                                            "location": "92x11->92x3902/3897->3901",
+                                                            "location": "3897->3901",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-name",
-                                                            "location": "92x16->92x3911/3902->3910",
+                                                            "location": "3902->3910",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:spaces",
-                                                    "location": "92x24->92x25/3910->3911",
+                                                    "location": "3910->3911",
                                                     "children": [],
                                                     "properties": {
                                                         "size": 1
@@ -3476,7 +3476,7 @@
                                                 },
                                                 {
                                                     "type": "at-html:param",
-                                                    "location": "92x25->111x10/3911->4478",
+                                                    "location": "3911->4478",
                                                     "children": [],
                                                     "properties": {
                                                         "value": "{\r\n            label: checkboxLabel,\r\n            onchange: {\r\n                fn: \"itemClick\",\r\n                args: {\r\n                    item : item,\r\n                    itemIdx : item.index\r\n                }\r\n            },\r\n            id: 'listItem' + item.index,\r\n            bind:{\r\n                \"value\": {\r\n                    inside: item, to: 'selected'\r\n                },\r\n                \"disabled\" : {\r\n                    inside : item, to: \"currentlyDisabled\"\r\n                    }\r\n            },\r\n            value: item.selected\r\n        }"
@@ -3484,14 +3484,14 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "111x10->111x4481/4478->4480",
+                                                    "location": "4478->4480",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "111x12->113x1/4480->4484",
+                                            "location": "4480->4484",
                                             "children": [],
                                             "properties": {
                                                 "size": 2
@@ -3499,7 +3499,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "113x1->113x4489/4484->4488",
+                                            "location": "4484->4488",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -3509,21 +3509,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "113x5->113x4497/4488->4496",
+                                    "location": "4488->4496",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "113x5->113x4491/4488->4490",
+                                            "location": "4488->4490",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "113x7->113x4496/4490->4495",
+                                            "location": "4490->4495",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "113x12->113x4497/4495->4496",
+                                            "location": "4495->4496",
                                             "children": []
                                         }
                                     ]
@@ -3532,7 +3532,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "113x13->115x1/4496->4500",
+                            "location": "4496->4500",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -3540,7 +3540,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "115x1->115x4505/4500->4504",
+                            "location": "4500->4504",
                             "children": [],
                             "properties": {
                                 "size": 4
@@ -3548,25 +3548,25 @@
                         },
                         {
                             "type": "at-html:block-statement",
-                            "location": "115x5->140x13/4504->5408",
+                            "location": "4504->5408",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "115x5->115x4521/4504->4520",
+                                    "location": "4504->4520",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "115x5->115x4506/4504->4505",
+                                            "location": "4504->4505",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "115x6->115x4511/4505->4510",
+                                            "location": "4505->4510",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "115x11->115x4512/4510->4511",
+                                            "location": "4510->4511",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3574,7 +3574,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "115x12->115x4520/4511->4519",
+                                            "location": "4511->4519",
                                             "children": [],
                                             "properties": {
                                                 "value": "footer()"
@@ -3582,18 +3582,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "115x20->115x4521/4519->4520",
+                                            "location": "4519->4520",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "115x21->140x5/4520->5400",
+                                    "location": "4520->5400",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "115x21->116x1/4520->4522",
+                                            "location": "4520->4522",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3601,7 +3601,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "116x1->116x4539/4522->4538",
+                                            "location": "4522->4538",
                                             "children": [],
                                             "properties": {
                                                 "size": 16
@@ -3609,32 +3609,32 @@
                                         },
                                         {
                                             "type": "at-html:inline-widget",
-                                            "location": "116x17->123x20/4538->4816",
+                                            "location": "4538->4816",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "116x17->116x4540/4538->4539",
+                                                    "location": "4538->4539",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-widget-id",
-                                                    "location": "116x18->116x4550/4539->4549",
+                                                    "location": "4539->4549",
                                                     "children": [
                                                         {
                                                             "type": "at-html:at-widget-library",
-                                                            "location": "116x19->116x4545/4540->4544",
+                                                            "location": "4540->4544",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-name",
-                                                            "location": "116x24->116x4550/4545->4549",
+                                                            "location": "4545->4549",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:spaces",
-                                                    "location": "116x28->116x29/4549->4550",
+                                                    "location": "4549->4550",
                                                     "children": [],
                                                     "properties": {
                                                         "size": 1
@@ -3642,7 +3642,7 @@
                                                 },
                                                 {
                                                     "type": "at-html:param",
-                                                    "location": "116x29->123x18/4550->4814",
+                                                    "location": "4550->4814",
                                                     "children": [],
                                                     "properties": {
                                                         "value": "{\r\n                    label : footerRes.selectAll,\r\n                    sclass : 'multiSelectFooter',\r\n                    onclick : {\r\n                        fn : \"selectAll\",\r\n                        scope : moduleCtrl\r\n                    }\r\n                }"
@@ -3650,14 +3650,14 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "123x18->123x4817/4814->4816",
+                                                    "location": "4814->4816",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "123x20->124x1/4816->4818",
+                                            "location": "4816->4818",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3665,7 +3665,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "124x1->124x4835/4818->4834",
+                                            "location": "4818->4834",
                                             "children": [],
                                             "properties": {
                                                 "size": 16
@@ -3673,32 +3673,32 @@
                                         },
                                         {
                                             "type": "at-html:inline-widget",
-                                            "location": "124x17->131x20/4834->5099",
+                                            "location": "4834->5099",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "124x17->124x4836/4834->4835",
+                                                    "location": "4834->4835",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-widget-id",
-                                                    "location": "124x18->124x4846/4835->4845",
+                                                    "location": "4835->4845",
                                                     "children": [
                                                         {
                                                             "type": "at-html:at-widget-library",
-                                                            "location": "124x19->124x4841/4836->4840",
+                                                            "location": "4836->4840",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-name",
-                                                            "location": "124x24->124x4846/4841->4845",
+                                                            "location": "4841->4845",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:spaces",
-                                                    "location": "124x28->124x29/4845->4846",
+                                                    "location": "4845->4846",
                                                     "children": [],
                                                     "properties": {
                                                         "size": 1
@@ -3706,7 +3706,7 @@
                                                 },
                                                 {
                                                     "type": "at-html:param",
-                                                    "location": "124x29->131x18/4846->5097",
+                                                    "location": "4846->5097",
                                                     "children": [],
                                                     "properties": {
                                                         "value": "{\r\n                    label:footerRes.close,\r\n                    sclass : 'multiSelectFooter',\r\n                    onclick: {\r\n                        fn: \"close\",\r\n                        scope: moduleCtrl\r\n                    }\r\n                }"
@@ -3714,14 +3714,14 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "131x18->131x5100/5097->5099",
+                                                    "location": "5097->5099",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "131x20->132x1/5099->5101",
+                                            "location": "5099->5101",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3729,7 +3729,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "132x1->132x5118/5101->5117",
+                                            "location": "5101->5117",
                                             "children": [],
                                             "properties": {
                                                 "size": 16
@@ -3737,32 +3737,32 @@
                                         },
                                         {
                                             "type": "at-html:inline-widget",
-                                            "location": "132x17->139x20/5117->5394",
+                                            "location": "5117->5394",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "132x17->132x5119/5117->5118",
+                                                    "location": "5117->5118",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-widget-id",
-                                                    "location": "132x18->132x5129/5118->5128",
+                                                    "location": "5118->5128",
                                                     "children": [
                                                         {
                                                             "type": "at-html:at-widget-library",
-                                                            "location": "132x19->132x5124/5119->5123",
+                                                            "location": "5119->5123",
                                                             "children": []
                                                         },
                                                         {
                                                             "type": "at-html:at-widget-name",
-                                                            "location": "132x24->132x5129/5124->5128",
+                                                            "location": "5124->5128",
                                                             "children": []
                                                         }
                                                     ]
                                                 },
                                                 {
                                                     "type": "at-html:spaces",
-                                                    "location": "132x28->132x29/5128->5129",
+                                                    "location": "5128->5129",
                                                     "children": [],
                                                     "properties": {
                                                         "size": 1
@@ -3770,7 +3770,7 @@
                                                 },
                                                 {
                                                     "type": "at-html:param",
-                                                    "location": "132x29->139x18/5129->5392",
+                                                    "location": "5129->5392",
                                                     "children": [],
                                                     "properties": {
                                                         "value": "{\r\n                    label:footerRes.deselectAll,\r\n                    sclass : 'multiSelectFooter',\r\n                    onclick: {\r\n                        fn: \"deselectAll\",\r\n                        scope: moduleCtrl\r\n                    }\r\n                }"
@@ -3778,14 +3778,14 @@
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "139x18->139x5395/5392->5394",
+                                                    "location": "5392->5394",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "139x20->140x1/5394->5396",
+                                            "location": "5394->5396",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -3793,7 +3793,7 @@
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "140x1->140x5401/5396->5400",
+                                            "location": "5396->5400",
                                             "children": [],
                                             "properties": {
                                                 "size": 4
@@ -3803,21 +3803,21 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "140x5->140x5409/5400->5408",
+                                    "location": "5400->5408",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "140x5->140x5403/5400->5402",
+                                            "location": "5400->5402",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-id",
-                                            "location": "140x7->140x5408/5402->5407",
+                                            "location": "5402->5407",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "140x12->140x5409/5407->5408",
+                                            "location": "5407->5408",
                                             "children": []
                                         }
                                     ]
@@ -3826,7 +3826,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "140x13->142x1/5408->5412",
+                            "location": "5408->5412",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -3836,21 +3836,21 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "142x1->142x5424/5412->5423",
+                    "location": "5412->5423",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "142x1->142x5415/5412->5414",
+                            "location": "5412->5414",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "142x3->142x5423/5414->5422",
+                            "location": "5414->5422",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "142x11->142x5424/5422->5423",
+                            "location": "5422->5423",
                             "children": []
                         }
                     ]
@@ -3859,7 +3859,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "142x12->143x1/5423->5425",
+            "location": "5423->5425",
             "children": [],
             "properties": {
                 "size": 1

--- a/test/app/node_modules/modes/at-html/parser/index/startSeven-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startSeven-output.json
@@ -1,28 +1,28 @@
 {
     "type": "at-html:root",
-    "location": "1x1->26x9/0->239",
+    "location": "0->239",
     "children": [
         {
             "type": "at-html:block-statement",
-            "location": "1x1->26x9/0->239",
+            "location": "0->239",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x18/0->17",
+                    "location": "0->17",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "1x1->1x2/0->1",
+                            "location": "0->1",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "1x2->1x7/1->6",
+                            "location": "1->6",
                             "children": []
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "1x7->1x8/6->7",
+                            "location": "6->7",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -30,7 +30,7 @@
                         },
                         {
                             "type": "at-html:param",
-                            "location": "1x8->1x17/7->16",
+                            "location": "7->16",
                             "children": [],
                             "properties": {
                                 "value": "myMacro()"
@@ -38,7 +38,7 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "1x17->1x18/16->17",
+                            "location": "16->17",
                             "children": []
                         }
                     ],
@@ -50,11 +50,11 @@
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "1x18->26x1/17->231",
+                    "location": "17->231",
                     "children": [
                         {
                             "type": "at-html:eols",
-                            "location": "1x18->3x1/17->21",
+                            "location": "17->21",
                             "children": [],
                             "properties": {
                                 "size": 2
@@ -62,28 +62,28 @@
                         },
                         {
                             "type": "at-html:html-comment",
-                            "location": "3x1->3x48/21->47",
+                            "location": "21->47",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "3x1->3x26/21->25",
+                                    "location": "21->25",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:content",
-                                    "location": "3x5->3x45/25->44",
+                                    "location": "25->44",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "3x24->3x48/44->47",
+                                    "location": "44->47",
                                     "children": []
                                 }
                             ]
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "3x27->4x1/47->49",
+                            "location": "47->49",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -91,21 +91,21 @@
                         },
                         {
                             "type": "at-html:inline-statement",
-                            "location": "4x1->4x63/49->62",
+                            "location": "49->62",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "4x1->4x51/49->50",
+                                    "location": "49->50",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:at-id",
-                                    "location": "4x2->4x54/50->53",
+                                    "location": "50->53",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:spaces",
-                                    "location": "4x5->4x6/53->54",
+                                    "location": "53->54",
                                     "children": [],
                                     "properties": {
                                         "size": 1
@@ -113,7 +113,7 @@
                                 },
                                 {
                                     "type": "at-html:param",
-                                    "location": "4x6->4x11/54->59",
+                                    "location": "54->59",
                                     "children": [],
                                     "properties": {
                                         "value": "a = 1"
@@ -121,7 +121,7 @@
                                 },
                                 {
                                     "type": "at-html:spaces",
-                                    "location": "4x11->4x12/59->60",
+                                    "location": "59->60",
                                     "children": [],
                                     "properties": {
                                         "size": 1
@@ -129,14 +129,14 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "4x12->4x63/60->62",
+                                    "location": "60->62",
                                     "children": []
                                 }
                             ]
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "4x14->5x1/62->64",
+                            "location": "62->64",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -144,36 +144,36 @@
                         },
                         {
                             "type": "at-html:block-widget",
-                            "location": "5x1->23x8/64->225",
+                            "location": "64->225",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "5x1->5x93/64->92",
+                                    "location": "64->92",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "5x1->5x66/64->65",
+                                            "location": "64->65",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-widget-id",
-                                            "location": "5x2->5x70/65->69",
+                                            "location": "65->69",
                                             "children": [
                                                 {
                                                     "type": "at-html:at-widget-library",
-                                                    "location": "5x3->5x68/66->67",
+                                                    "location": "66->67",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-widget-name",
-                                                    "location": "5x5->5x70/68->69",
+                                                    "location": "68->69",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:spaces",
-                                            "location": "5x6->5x71/69->70",
+                                            "location": "69->70",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -181,7 +181,7 @@
                                         },
                                         {
                                             "type": "at-html:param",
-                                            "location": "5x7->5x92/70->91",
+                                            "location": "70->91",
                                             "children": [],
                                             "properties": {
                                                 "value": "sdfbhsdbjfsdhjsdfjl{}"
@@ -189,18 +189,18 @@
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "5x28->5x93/91->92",
+                                            "location": "91->92",
                                             "children": []
                                         }
                                     ]
                                 },
                                 {
                                     "type": "at-html:block-statement-content",
-                                    "location": "5x29->23x1/92->218",
+                                    "location": "92->218",
                                     "children": [
                                         {
                                             "type": "at-html:eols",
-                                            "location": "5x29->7x1/92->96",
+                                            "location": "92->96",
                                             "children": [],
                                             "properties": {
                                                 "size": 2
@@ -208,7 +208,7 @@
                                         },
                                         {
                                             "type": "at-html:tabs",
-                                            "location": "7x1->7x98/96->97",
+                                            "location": "96->97",
                                             "children": [],
                                             "properties": {
                                                 "size": 1
@@ -216,28 +216,28 @@
                                         },
                                         {
                                             "type": "at-html:html-cdata",
-                                            "location": "7x2->15x4/97->185",
+                                            "location": "97->185",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "7x2->7x107/97->106",
+                                                    "location": "97->106",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:content",
-                                                    "location": "7x11->15x1/106->182",
+                                                    "location": "106->182",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "15x1->15x186/182->185",
+                                                    "location": "182->185",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "15x4->17x1/185->189",
+                                            "location": "185->189",
                                             "children": [],
                                             "properties": {
                                                 "size": 2
@@ -245,28 +245,28 @@
                                         },
                                         {
                                             "type": "at-html:multi-line-comment",
-                                            "location": "17x1->20x3/189->212",
+                                            "location": "189->212",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "17x1->17x192/189->191",
+                                                    "location": "189->191",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:content",
-                                                    "location": "17x3->20x1/191->210",
+                                                    "location": "191->210",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "20x1->20x213/210->212",
+                                                    "location": "210->212",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:eols",
-                                            "location": "20x3->23x1/212->218",
+                                            "location": "212->218",
                                             "children": [],
                                             "properties": {
                                                 "size": 3
@@ -276,32 +276,32 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "23x1->23x226/218->225",
+                                    "location": "218->225",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "23x1->23x221/218->220",
+                                            "location": "218->220",
                                             "children": []
                                         },
                                         {
                                             "type": "at-html:at-widget-id",
-                                            "location": "23x3->23x225/220->224",
+                                            "location": "220->224",
                                             "children": [
                                                 {
                                                     "type": "at-html:at-widget-library",
-                                                    "location": "23x4->23x223/221->222",
+                                                    "location": "221->222",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-widget-name",
-                                                    "location": "23x6->23x225/223->224",
+                                                    "location": "223->224",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "23x7->23x226/224->225",
+                                            "location": "224->225",
                                             "children": []
                                         }
                                     ]
@@ -310,7 +310,7 @@
                         },
                         {
                             "type": "at-html:eols",
-                            "location": "23x8->26x1/225->231",
+                            "location": "225->231",
                             "children": [],
                             "properties": {
                                 "size": 3
@@ -320,21 +320,21 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "26x1->26x240/231->239",
+                    "location": "231->239",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "26x1->26x234/231->233",
+                            "location": "231->233",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "26x3->26x239/233->238",
+                            "location": "233->238",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "26x8->26x240/238->239",
+                            "location": "238->239",
                             "children": []
                         }
                     ]

--- a/test/app/node_modules/modes/at-html/parser/index/startSix-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startSix-output.json
@@ -1,10 +1,10 @@
 {
     "type": "at-html:root",
-    "location": "1x1->1x3/0->2",
+    "location": "0->2",
     "children": [
         {
             "type": "at-html:html-element",
-            "location": "1x1->1x3/0->2",
+            "location": "0->2",
             "children": [],
             "properties": {
                 "errors": [

--- a/test/app/node_modules/modes/at-html/parser/index/startThree-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startThree-output.json
@@ -1,35 +1,35 @@
 {
     "type": "at-html:root",
-    "location": "1x1->4x8/0->34",
+    "location": "0->34",
     "children": [
         {
             "type": "at-html:inline-widget",
-            "location": "1x1->1x12/0->11",
+            "location": "0->11",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x2/0->1",
+                    "location": "0->1",
                     "children": []
                 },
                 {
                     "type": "at-html:at-widget-id",
-                    "location": "1x2->1x6/1->5",
+                    "location": "1->5",
                     "children": [
                         {
                             "type": "at-html:at-widget-library",
-                            "location": "1x3->1x4/2->3",
+                            "location": "2->3",
                             "children": []
                         },
                         {
                             "type": "at-html:at-widget-name",
-                            "location": "1x5->1x6/4->5",
+                            "location": "4->5",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "1x6->1x7/5->6",
+                    "location": "5->6",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -37,7 +37,7 @@
                 },
                 {
                     "type": "at-html:param",
-                    "location": "1x7->1x9/6->8",
+                    "location": "6->8",
                     "children": [],
                     "properties": {
                         "value": "{}"
@@ -45,7 +45,7 @@
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "1x9->1x10/8->9",
+                    "location": "8->9",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -53,7 +53,7 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x10->1x12/9->11",
+                    "location": "9->11",
                     "children": []
                 }
             ],
@@ -66,7 +66,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "1x12->3x1/11->15",
+            "location": "11->15",
             "children": [],
             "properties": {
                 "size": 2
@@ -74,36 +74,36 @@
         },
         {
             "type": "at-html:block-widget",
-            "location": "3x1->4x8/15->34",
+            "location": "15->34",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "3x1->3x26/15->25",
+                    "location": "15->25",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "3x1->3x17/15->16",
+                            "location": "15->16",
                             "children": []
                         },
                         {
                             "type": "at-html:at-widget-id",
-                            "location": "3x2->3x21/16->20",
+                            "location": "16->20",
                             "children": [
                                 {
                                     "type": "at-html:at-widget-library",
-                                    "location": "3x3->3x19/17->18",
+                                    "location": "17->18",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:at-widget-name",
-                                    "location": "3x5->3x21/19->20",
+                                    "location": "19->20",
                                     "children": []
                                 }
                             ]
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "3x6->3x22/20->21",
+                            "location": "20->21",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -111,7 +111,7 @@
                         },
                         {
                             "type": "at-html:param",
-                            "location": "3x7->3x24/21->23",
+                            "location": "21->23",
                             "children": [],
                             "properties": {
                                 "value": "{}"
@@ -119,7 +119,7 @@
                         },
                         {
                             "type": "at-html:spaces",
-                            "location": "3x9->3x25/23->24",
+                            "location": "23->24",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -127,7 +127,7 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "3x10->3x26/24->25",
+                            "location": "24->25",
                             "children": []
                         }
                     ],
@@ -140,11 +140,11 @@
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "3x11->4x1/25->27",
+                    "location": "25->27",
                     "children": [
                         {
                             "type": "at-html:eols",
-                            "location": "3x11->4x1/25->27",
+                            "location": "25->27",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -154,32 +154,32 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "4x1->4x35/27->34",
+                    "location": "27->34",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "4x1->4x30/27->29",
+                            "location": "27->29",
                             "children": []
                         },
                         {
                             "type": "at-html:at-widget-id",
-                            "location": "4x3->4x34/29->33",
+                            "location": "29->33",
                             "children": [
                                 {
                                     "type": "at-html:at-widget-library",
-                                    "location": "4x4->4x32/30->31",
+                                    "location": "30->31",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:at-widget-name",
-                                    "location": "4x6->4x34/32->33",
+                                    "location": "32->33",
                                     "children": []
                                 }
                             ]
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "4x7->4x35/33->34",
+                            "location": "33->34",
                             "children": []
                         }
                     ]

--- a/test/app/node_modules/modes/at-html/parser/index/startTwo-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/startTwo-output.json
@@ -1,24 +1,24 @@
 {
     "type": "at-html:root",
-    "location": "1x1->5x7/0->40",
+    "location": "0->40",
     "children": [
         {
             "type": "at-html:inline-statement",
-            "location": "1x1->1x13/0->12",
+            "location": "0->12",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x2/0->1",
+                    "location": "0->1",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "1x2->1x5/1->4",
+                    "location": "1->4",
                     "children": []
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "1x5->1x6/4->5",
+                    "location": "4->5",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -26,7 +26,7 @@
                 },
                 {
                     "type": "at-html:param",
-                    "location": "1x6->1x11/5->10",
+                    "location": "5->10",
                     "children": [],
                     "properties": {
                         "value": "a = 1"
@@ -34,14 +34,14 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x11->1x13/10->12",
+                    "location": "10->12",
                     "children": []
                 }
             ]
         },
         {
             "type": "at-html:eols",
-            "location": "1x13->3x1/12->16",
+            "location": "12->16",
             "children": [],
             "properties": {
                 "size": 2
@@ -49,25 +49,25 @@
         },
         {
             "type": "at-html:block-statement",
-            "location": "3x1->4x8/16->32",
+            "location": "16->32",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "3x1->3x24/16->23",
+                    "location": "16->23",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "3x1->3x18/16->17",
+                            "location": "16->17",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "3x2->3x23/17->22",
+                            "location": "17->22",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "3x7->3x24/22->23",
+                            "location": "22->23",
                             "children": []
                         }
                     ],
@@ -80,11 +80,11 @@
                 },
                 {
                     "type": "at-html:block-statement-content",
-                    "location": "3x8->4x1/23->25",
+                    "location": "23->25",
                     "children": [
                         {
                             "type": "at-html:eols",
-                            "location": "3x8->4x1/23->25",
+                            "location": "23->25",
                             "children": [],
                             "properties": {
                                 "size": 1
@@ -94,21 +94,21 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "4x1->4x33/25->32",
+                    "location": "25->32",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "4x1->4x28/25->27",
+                            "location": "25->27",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "4x3->4x32/27->31",
+                            "location": "27->31",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "4x7->4x33/31->32",
+                            "location": "31->32",
                             "children": []
                         }
                     ],
@@ -123,7 +123,7 @@
         },
         {
             "type": "at-html:eols",
-            "location": "4x8->5x1/32->34",
+            "location": "32->34",
             "children": [],
             "properties": {
                 "size": 1
@@ -131,25 +131,25 @@
         },
         {
             "type": "at-html:block-statement",
-            "location": "5x1->5x41/34->40",
+            "location": "34->40",
             "children": [
                 {
                     "type": "at-html:closing",
-                    "location": "5x1->5x41/34->40",
+                    "location": "34->40",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "5x1->5x37/34->36",
+                            "location": "34->36",
                             "children": []
                         },
                         {
                             "type": "at-html:at-id",
-                            "location": "5x3->5x40/36->39",
+                            "location": "36->39",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "5x6->5x41/39->40",
+                            "location": "39->40",
                             "children": []
                         }
                     ],

--- a/test/app/node_modules/modes/at-html/parser/index/statementOne-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/statementOne-output.json
@@ -1,24 +1,24 @@
 {
     "type": "at-html:block-statement",
-    "location": "1x1->11x7/0->153",
+    "location": "0->153",
     "children": [
         {
             "type": "at-html:opening",
-            "location": "1x1->1x7/0->6",
+            "location": "0->6",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "1x1->1x2/0->1",
+                    "location": "0->1",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "1x2->1x5/1->4",
+                    "location": "1->4",
                     "children": []
                 },
                 {
                     "type": "at-html:spaces",
-                    "location": "1x5->1x6/4->5",
+                    "location": "4->5",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -26,7 +26,7 @@
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "1x6->1x7/5->6",
+                    "location": "5->6",
                     "children": []
                 }
             ],
@@ -40,11 +40,11 @@
         },
         {
             "type": "at-html:block-statement-content",
-            "location": "1x7->11x1/6->147",
+            "location": "6->147",
             "children": [
                 {
                     "type": "at-html:eols",
-                    "location": "1x7->2x1/6->8",
+                    "location": "6->8",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -52,7 +52,7 @@
                 },
                 {
                     "type": "at-html:tabs",
-                    "location": "2x1->2x10/8->9",
+                    "location": "8->9",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -60,21 +60,21 @@
                 },
                 {
                     "type": "at-html:text",
-                    "location": "2x2->3x2/9->24",
+                    "location": "9->24",
                     "children": []
                 },
                 {
                     "type": "at-html:expression",
-                    "location": "3x2->3x33/24->32",
+                    "location": "24->32",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "3x2->3x27/24->26",
+                            "location": "24->26",
                             "children": []
                         },
                         {
                             "type": "at-html:param",
-                            "location": "3x4->3x32/26->31",
+                            "location": "26->31",
                             "children": [],
                             "properties": {
                                 "value": "dmkks"
@@ -82,14 +82,14 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "3x9->3x33/31->32",
+                            "location": "31->32",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:eols",
-                    "location": "3x10->4x1/32->34",
+                    "location": "32->34",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -97,7 +97,7 @@
                 },
                 {
                     "type": "at-html:tabs",
-                    "location": "4x1->4x36/34->35",
+                    "location": "34->35",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -105,28 +105,28 @@
                 },
                 {
                     "type": "at-html:multi-line-comment",
-                    "location": "4x2->6x4/35->60",
+                    "location": "35->60",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "4x2->4x38/35->37",
+                            "location": "35->37",
                             "children": []
                         },
                         {
                             "type": "at-html:content",
-                            "location": "4x4->6x2/37->58",
+                            "location": "37->58",
                             "children": []
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "6x2->6x61/58->60",
+                            "location": "58->60",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:eols",
-                    "location": "6x4->7x1/60->62",
+                    "location": "60->62",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -134,7 +134,7 @@
                 },
                 {
                     "type": "at-html:tabs",
-                    "location": "7x1->7x64/62->63",
+                    "location": "62->63",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -142,23 +142,23 @@
                 },
                 {
                     "type": "at-html:single-line-comment",
-                    "location": "7x2->7x81/63->80",
+                    "location": "63->80",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "7x2->7x66/63->65",
+                            "location": "63->65",
                             "children": []
                         },
                         {
                             "type": "at-html:content",
-                            "location": "7x4->7x81/65->80",
+                            "location": "65->80",
                             "children": []
                         }
                     ]
                 },
                 {
                     "type": "at-html:eols",
-                    "location": "7x19->8x1/80->82",
+                    "location": "80->82",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -166,7 +166,7 @@
                 },
                 {
                     "type": "at-html:tabs",
-                    "location": "8x1->8x84/82->83",
+                    "location": "82->83",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -174,25 +174,25 @@
                 },
                 {
                     "type": "at-html:block-statement",
-                    "location": "8x2->10x12/83->145",
+                    "location": "83->145",
                     "children": [
                         {
                             "type": "at-html:opening",
-                            "location": "8x2->8x105/83->104",
+                            "location": "83->104",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "8x2->8x85/83->84",
+                                    "location": "83->84",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:at-id",
-                                    "location": "8x3->8x92/84->91",
+                                    "location": "84->91",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:spaces",
-                                    "location": "8x10->8x93/91->92",
+                                    "location": "91->92",
                                     "children": [],
                                     "properties": {
                                         "size": 1
@@ -200,7 +200,7 @@
                                 },
                                 {
                                     "type": "at-html:param",
-                                    "location": "8x11->8x104/92->103",
+                                    "location": "92->103",
                                     "children": [],
                                     "properties": {
                                         "value": "t inArray j"
@@ -208,7 +208,7 @@
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "8x22->8x105/103->104",
+                                    "location": "103->104",
                                     "children": []
                                 }
                             ],
@@ -220,11 +220,11 @@
                         },
                         {
                             "type": "at-html:block-statement-content",
-                            "location": "8x23->10x2/104->135",
+                            "location": "104->135",
                             "children": [
                                 {
                                     "type": "at-html:eols",
-                                    "location": "8x23->9x1/104->106",
+                                    "location": "104->106",
                                     "children": [],
                                     "properties": {
                                         "size": 1
@@ -232,7 +232,7 @@
                                 },
                                 {
                                     "type": "at-html:tabs",
-                                    "location": "9x1->9x109/106->108",
+                                    "location": "106->108",
                                     "children": [],
                                     "properties": {
                                         "size": 2
@@ -240,25 +240,25 @@
                                 },
                                 {
                                     "type": "at-html:block-statement",
-                                    "location": "9x3->9x133/108->132",
+                                    "location": "108->132",
                                     "children": [
                                         {
                                             "type": "at-html:opening",
-                                            "location": "9x3->9x120/108->119",
+                                            "location": "108->119",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "9x3->9x110/108->109",
+                                                    "location": "108->109",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-id",
-                                                    "location": "9x4->9x119/109->118",
+                                                    "location": "109->118",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "9x13->9x120/118->119",
+                                                    "location": "118->119",
                                                     "children": []
                                                 }
                                             ],
@@ -270,32 +270,32 @@
                                         },
                                         {
                                             "type": "at-html:block-statement-content",
-                                            "location": "9x14->9x121/119->120",
+                                            "location": "119->120",
                                             "children": [
                                                 {
                                                     "type": "at-html:text",
-                                                    "location": "9x14->9x121/119->120",
+                                                    "location": "119->120",
                                                     "children": []
                                                 }
                                             ]
                                         },
                                         {
                                             "type": "at-html:closing",
-                                            "location": "9x15->9x133/120->132",
+                                            "location": "120->132",
                                             "children": [
                                                 {
                                                     "type": "at-html:opening",
-                                                    "location": "9x15->9x123/120->122",
+                                                    "location": "120->122",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:at-id",
-                                                    "location": "9x17->9x132/122->131",
+                                                    "location": "122->131",
                                                     "children": []
                                                 },
                                                 {
                                                     "type": "at-html:closing",
-                                                    "location": "9x26->9x133/131->132",
+                                                    "location": "131->132",
                                                     "children": []
                                                 }
                                             ]
@@ -304,7 +304,7 @@
                                 },
                                 {
                                     "type": "at-html:eols",
-                                    "location": "9x27->10x1/132->134",
+                                    "location": "132->134",
                                     "children": [],
                                     "properties": {
                                         "size": 1
@@ -312,7 +312,7 @@
                                 },
                                 {
                                     "type": "at-html:tabs",
-                                    "location": "10x1->10x136/134->135",
+                                    "location": "134->135",
                                     "children": [],
                                     "properties": {
                                         "size": 1
@@ -322,21 +322,21 @@
                         },
                         {
                             "type": "at-html:closing",
-                            "location": "10x2->10x146/135->145",
+                            "location": "135->145",
                             "children": [
                                 {
                                     "type": "at-html:opening",
-                                    "location": "10x2->10x138/135->137",
+                                    "location": "135->137",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:at-id",
-                                    "location": "10x4->10x145/137->144",
+                                    "location": "137->144",
                                     "children": []
                                 },
                                 {
                                     "type": "at-html:closing",
-                                    "location": "10x11->10x146/144->145",
+                                    "location": "144->145",
                                     "children": []
                                 }
                             ]
@@ -345,7 +345,7 @@
                 },
                 {
                     "type": "at-html:eols",
-                    "location": "10x12->11x1/145->147",
+                    "location": "145->147",
                     "children": [],
                     "properties": {
                         "size": 1
@@ -355,21 +355,21 @@
         },
         {
             "type": "at-html:closing",
-            "location": "11x1->11x154/147->153",
+            "location": "147->153",
             "children": [
                 {
                     "type": "at-html:opening",
-                    "location": "11x1->11x150/147->149",
+                    "location": "147->149",
                     "children": []
                 },
                 {
                     "type": "at-html:at-id",
-                    "location": "11x3->11x153/149->152",
+                    "location": "149->152",
                     "children": []
                 },
                 {
                     "type": "at-html:closing",
-                    "location": "11x6->11x154/152->153",
+                    "location": "152->153",
                     "children": []
                 }
             ],

--- a/test/app/node_modules/modes/at-html/parser/index/statementOpeningWithoutClosing-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/statementOpeningWithoutClosing-output.json
@@ -1,6 +1,6 @@
 {
     "type": "at-html:statement",
-    "location": "1x1->6x1/0->56",
+    "location": "0->56",
     "children": [],
     "properties": {
         "errors": [

--- a/test/app/node_modules/modes/at-html/parser/index/tabs-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/tabs-output.json
@@ -1,6 +1,6 @@
 {
     "type": "at-html:tabs",
-    "location": "1x1->1x5/0->4",
+    "location": "0->4",
     "children": [],
     "properties": {
         "size": 4

--- a/test/app/node_modules/modes/at-html/parser/index/text-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/text-output.json
@@ -1,12 +1,12 @@
 [
     {
         "type": "at-html:text",
-        "location": "1x1->1x61/0->60",
+        "location": "0->60",
         "children": []
     },
     {
         "type": "at-html:text",
-        "location": "1x1->2x9/0->33",
+        "location": "0->33",
         "children": []
     }
 ]

--- a/test/app/node_modules/modes/at-html/parser/index/widgetId-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/widgetId-output.json
@@ -1,39 +1,39 @@
 [
     {
         "type": "at-html:at-widget-id",
-        "location": "1x1->1x19/0->18",
+        "location": "0->18",
         "children": [
             {
                 "type": "at-html:at-widget-library",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             },
             {
                 "type": "at-html:at-widget-name",
-                "location": "1x7->1x19/6->18",
+                "location": "6->18",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:at-widget-id",
-        "location": "1x1->1x12/0->11",
+        "location": "0->11",
         "children": [
             {
                 "type": "at-html:at-widget-library",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             },
             {
                 "type": "at-html:at-widget-name",
-                "location": "1x7->1x12/6->11",
+                "location": "6->11",
                 "children": []
             }
         ]
     },
     {
         "type": "at-html:at-widget-id",
-        "location": "1x1->1x2/0->1",
+        "location": "0->1",
         "children": [],
         "properties": {
             "errors": [
@@ -44,7 +44,7 @@
     },
     {
         "type": "at-html:at-widget-id",
-        "location": "1x1->1x3/0->2",
+        "location": "0->2",
         "children": [],
         "properties": {
             "errors": [
@@ -55,11 +55,11 @@
     },
     {
         "type": "at-html:at-widget-id",
-        "location": "1x1->1x6/0->5",
+        "location": "0->5",
         "children": [
             {
                 "type": "at-html:at-widget-library",
-                "location": "1x2->1x6/1->5",
+                "location": "1->5",
                 "children": []
             }
         ],
@@ -71,11 +71,11 @@
     },
     {
         "type": "at-html:at-widget-id",
-        "location": "1x1->1x10/0->9",
+        "location": "0->9",
         "children": [
             {
                 "type": "at-html:at-widget-name",
-                "location": "1x3->1x10/2->9",
+                "location": "2->9",
                 "children": []
             }
         ],

--- a/test/app/node_modules/modes/at-html/parser/index/wsSequence-output.json
+++ b/test/app/node_modules/modes/at-html/parser/index/wsSequence-output.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "at-html:eols",
-        "location": "1x1->4x1/0->6",
+        "location": "0->6",
         "children": [],
         "properties": {
             "size": 3
@@ -9,7 +9,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "4x1->4x12/6->11",
+        "location": "6->11",
         "children": [],
         "properties": {
             "size": 5
@@ -17,7 +17,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "4x6->4x14/11->13",
+        "location": "11->13",
         "children": [],
         "properties": {
             "size": 2
@@ -25,7 +25,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "4x8->4x15/13->14",
+        "location": "13->14",
         "children": [],
         "properties": {
             "size": 1
@@ -33,7 +33,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "4x9->4x16/14->15",
+        "location": "14->15",
         "children": [],
         "properties": {
             "size": 1
@@ -41,7 +41,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "4x10->4x17/15->16",
+        "location": "15->16",
         "children": [],
         "properties": {
             "size": 1
@@ -49,7 +49,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "4x11->4x18/16->17",
+        "location": "16->17",
         "children": [],
         "properties": {
             "size": 1
@@ -57,7 +57,7 @@
     },
     {
         "type": "at-html:eols",
-        "location": "4x12->5x1/17->19",
+        "location": "17->19",
         "children": [],
         "properties": {
             "size": 1
@@ -65,7 +65,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "5x1->5x25/19->24",
+        "location": "19->24",
         "children": [],
         "properties": {
             "size": 5
@@ -73,7 +73,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "5x6->5x27/24->26",
+        "location": "24->26",
         "children": [],
         "properties": {
             "size": 2
@@ -81,7 +81,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "5x8->5x28/26->27",
+        "location": "26->27",
         "children": [],
         "properties": {
             "size": 1
@@ -89,7 +89,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "5x9->5x29/27->28",
+        "location": "27->28",
         "children": [],
         "properties": {
             "size": 1
@@ -97,7 +97,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "5x10->5x30/28->29",
+        "location": "28->29",
         "children": [],
         "properties": {
             "size": 1
@@ -105,7 +105,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "5x11->5x32/29->31",
+        "location": "29->31",
         "children": [],
         "properties": {
             "size": 2
@@ -113,7 +113,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "5x13->5x33/31->32",
+        "location": "31->32",
         "children": [],
         "properties": {
             "size": 1
@@ -121,7 +121,7 @@
     },
     {
         "type": "at-html:tabs",
-        "location": "5x14->5x34/32->33",
+        "location": "32->33",
         "children": [],
         "properties": {
             "size": 1
@@ -129,7 +129,7 @@
     },
     {
         "type": "at-html:spaces",
-        "location": "5x15->5x35/33->34",
+        "location": "33->34",
         "children": [],
         "properties": {
             "size": 1

--- a/test/app/node_modules/modes/html/parser/index/attributeList-output.json
+++ b/test/app/node_modules/modes/html/parser/index/attributeList-output.json
@@ -1,21 +1,21 @@
 [
     {
         "type": "html:attribute",
-        "location": "1x1->1x23/0->22",
+        "location": "0->22",
         "children": [
             {
                 "type": "html:id",
-                "location": "1x1->1x9/0->8",
+                "location": "0->8",
                 "children": []
             },
             {
                 "type": "html:binary-operator",
-                "location": "1x9->1x10/8->9",
+                "location": "8->9",
                 "children": []
             },
             {
                 "type": "html:spaces",
-                "location": "1x10->1x11/9->10",
+                "location": "9->10",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -23,21 +23,21 @@
             },
             {
                 "type": "html:string",
-                "location": "1x11->1x23/10->22",
+                "location": "10->22",
                 "children": [
                     {
                         "type": "html:quotes.double",
-                        "location": "1x11->1x12/10->11",
+                        "location": "10->11",
                         "children": []
                     },
                     {
                         "type": "html:doubleQuoteString.content",
-                        "location": "1x12->1x22/11->21",
+                        "location": "11->21",
                         "children": []
                     },
                     {
                         "type": "html:quotes.double",
-                        "location": "1x22->1x23/21->22",
+                        "location": "21->22",
                         "children": []
                     }
                 ]
@@ -46,7 +46,7 @@
     },
     {
         "type": "html:spaces",
-        "location": "1x23->1x24/22->23",
+        "location": "22->23",
         "children": [],
         "properties": {
             "size": 1
@@ -54,18 +54,18 @@
     },
     {
         "type": "html:attribute",
-        "location": "1x24->1x32/23->31",
+        "location": "23->31",
         "children": [
             {
                 "type": "html:id",
-                "location": "1x24->1x32/23->31",
+                "location": "23->31",
                 "children": []
             }
         ]
     },
     {
         "type": "html:spaces",
-        "location": "1x32->1x33/31->32",
+        "location": "31->32",
         "children": [],
         "properties": {
             "size": 1
@@ -73,16 +73,16 @@
     },
     {
         "type": "html:attribute",
-        "location": "1x33->1x55/32->54",
+        "location": "32->54",
         "children": [
             {
                 "type": "html:id",
-                "location": "1x33->1x41/32->40",
+                "location": "32->40",
                 "children": []
             },
             {
                 "type": "html:spaces",
-                "location": "1x41->1x42/40->41",
+                "location": "40->41",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -90,26 +90,26 @@
             },
             {
                 "type": "html:binary-operator",
-                "location": "1x42->1x43/41->42",
+                "location": "41->42",
                 "children": []
             },
             {
                 "type": "html:string",
-                "location": "1x43->1x55/42->54",
+                "location": "42->54",
                 "children": [
                     {
                         "type": "html:quotes.double",
-                        "location": "1x43->1x44/42->43",
+                        "location": "42->43",
                         "children": []
                     },
                     {
                         "type": "html:doubleQuoteString.content",
-                        "location": "1x44->1x54/43->53",
+                        "location": "43->53",
                         "children": []
                     },
                     {
                         "type": "html:quotes.double",
-                        "location": "1x54->1x55/53->54",
+                        "location": "53->54",
                         "children": []
                     }
                 ]
@@ -118,7 +118,7 @@
     },
     {
         "type": "html:spaces",
-        "location": "1x55->1x56/54->55",
+        "location": "54->55",
         "children": [],
         "properties": {
             "size": 1
@@ -126,35 +126,35 @@
     },
     {
         "type": "html:attribute",
-        "location": "1x56->1x74/55->73",
+        "location": "55->73",
         "children": [
             {
                 "type": "html:id",
-                "location": "1x56->1x64/55->63",
+                "location": "55->63",
                 "children": []
             },
             {
                 "type": "html:binary-operator",
-                "location": "1x64->1x65/63->64",
+                "location": "63->64",
                 "children": []
             },
             {
                 "type": "html:string",
-                "location": "1x65->1x74/64->73",
+                "location": "64->73",
                 "children": [
                     {
                         "type": "html:quotes.double",
-                        "location": "1x65->1x66/64->65",
+                        "location": "64->65",
                         "children": []
                     },
                     {
                         "type": "html:doubleQuoteString.content",
-                        "location": "1x66->1x73/65->72",
+                        "location": "65->72",
                         "children": []
                     },
                     {
                         "type": "html:quotes.double",
-                        "location": "1x73->1x74/72->73",
+                        "location": "72->73",
                         "children": []
                     }
                 ]
@@ -163,7 +163,7 @@
     },
     {
         "type": "html:spaces",
-        "location": "1x74->1x75/73->74",
+        "location": "73->74",
         "children": [],
         "properties": {
             "size": 1
@@ -171,16 +171,16 @@
     },
     {
         "type": "html:attribute",
-        "location": "1x75->1x96/74->95",
+        "location": "74->95",
         "children": [
             {
                 "type": "html:id",
-                "location": "1x75->1x84/74->83",
+                "location": "74->83",
                 "children": []
             },
             {
                 "type": "html:spaces",
-                "location": "1x84->1x85/83->84",
+                "location": "83->84",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -188,12 +188,12 @@
             },
             {
                 "type": "html:binary-operator",
-                "location": "1x85->1x86/84->85",
+                "location": "84->85",
                 "children": []
             },
             {
                 "type": "html:spaces",
-                "location": "1x86->1x87/85->86",
+                "location": "85->86",
                 "children": [],
                 "properties": {
                     "size": 1
@@ -201,21 +201,21 @@
             },
             {
                 "type": "html:string",
-                "location": "1x87->1x96/86->95",
+                "location": "86->95",
                 "children": [
                     {
                         "type": "html:quotes.double",
-                        "location": "1x87->1x88/86->87",
+                        "location": "86->87",
                         "children": []
                     },
                     {
                         "type": "html:doubleQuoteString.content",
-                        "location": "1x88->1x95/87->94",
+                        "location": "87->94",
                         "children": []
                     },
                     {
                         "type": "html:quotes.double",
-                        "location": "1x95->1x96/94->95",
+                        "location": "94->95",
                         "children": []
                     }
                 ]

--- a/test/app/node_modules/modes/html/parser/index/closingAngleBracket-output.json
+++ b/test/app/node_modules/modes/html/parser/index/closingAngleBracket-output.json
@@ -1,5 +1,5 @@
 {
     "type": "html:brackets.angle.closing",
-    "location": "1x1->1x2/0->1",
+    "location": "0->1",
     "children": []
 }

--- a/test/app/node_modules/modes/html/parser/index/comment-output.json
+++ b/test/app/node_modules/modes/html/parser/index/comment-output.json
@@ -1,20 +1,20 @@
 {
     "type": "html:comment",
-    "location": "1x1->3x25/0->59",
+    "location": "0->59",
     "children": [
         {
             "type": "html:opening",
-            "location": "1x1->1x5/0->4",
+            "location": "0->4",
             "children": []
         },
         {
             "type": "html:content",
-            "location": "1x5->3x22/4->56",
+            "location": "4->56",
             "children": []
         },
         {
             "type": "html:closing",
-            "location": "3x22->3x60/56->59",
+            "location": "56->59",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/html/parser/index/doubleQuoteString-output.json
+++ b/test/app/node_modules/modes/html/parser/index/doubleQuoteString-output.json
@@ -1,20 +1,20 @@
 {
     "type": "html:string",
-    "location": "1x1->1x48/0->47",
+    "location": "0->47",
     "children": [
         {
             "type": "html:quotes.double",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "html:doubleQuoteString.content",
-            "location": "1x2->1x47/1->46",
+            "location": "1->46",
             "children": []
         },
         {
             "type": "html:quotes.double",
-            "location": "1x47->1x48/46->47",
+            "location": "46->47",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/html/parser/index/eols-output.json
+++ b/test/app/node_modules/modes/html/parser/index/eols-output.json
@@ -1,10 +1,10 @@
 {
     "type": "html:eols",
-    "location": "1x1->9x1/0->16",
+    "location": "0->16",
     "children": [
         {
             "type": "html:eol",
-            "location": "1x1->2x1/0->2",
+            "location": "0->2",
             "children": [],
             "properties": {
                 "value": "\r\n"
@@ -12,7 +12,7 @@
         },
         {
             "type": "html:eol",
-            "location": "2x1->3x1/2->4",
+            "location": "2->4",
             "children": [],
             "properties": {
                 "value": "\r\n"
@@ -20,7 +20,7 @@
         },
         {
             "type": "html:eol",
-            "location": "3x1->4x1/4->6",
+            "location": "4->6",
             "children": [],
             "properties": {
                 "value": "\r\n"
@@ -28,7 +28,7 @@
         },
         {
             "type": "html:eol",
-            "location": "4x1->5x1/6->8",
+            "location": "6->8",
             "children": [],
             "properties": {
                 "value": "\r\n"
@@ -36,7 +36,7 @@
         },
         {
             "type": "html:eol",
-            "location": "5x1->6x1/8->10",
+            "location": "8->10",
             "children": [],
             "properties": {
                 "value": "\r\n"
@@ -44,7 +44,7 @@
         },
         {
             "type": "html:eol",
-            "location": "6x1->7x1/10->12",
+            "location": "10->12",
             "children": [],
             "properties": {
                 "value": "\r\n"
@@ -52,7 +52,7 @@
         },
         {
             "type": "html:eol",
-            "location": "7x1->8x1/12->14",
+            "location": "12->14",
             "children": [],
             "properties": {
                 "value": "\r\n"
@@ -60,7 +60,7 @@
         },
         {
             "type": "html:eol",
-            "location": "8x1->9x1/14->16",
+            "location": "14->16",
             "children": [],
             "properties": {
                 "value": "\r\n"

--- a/test/app/node_modules/modes/html/parser/index/id-output.json
+++ b/test/app/node_modules/modes/html/parser/index/id-output.json
@@ -1,12 +1,12 @@
 [
     {
         "type": "html:id",
-        "location": "1x1->1x19/0->18",
+        "location": "0->18",
         "children": []
     },
     {
         "type": "html:id",
-        "location": "1x1->1x17/0->16",
+        "location": "0->16",
         "children": []
     }
 ]

--- a/test/app/node_modules/modes/html/parser/index/simpleQuoteString-output.json
+++ b/test/app/node_modules/modes/html/parser/index/simpleQuoteString-output.json
@@ -1,20 +1,20 @@
 {
     "type": "html:string",
-    "location": "1x1->1x66/0->65",
+    "location": "0->65",
     "children": [
         {
             "type": "html:quotes.simple",
-            "location": "1x1->1x2/0->1",
+            "location": "0->1",
             "children": []
         },
         {
             "type": "html:simpleQuoteString.content",
-            "location": "1x2->1x65/1->64",
+            "location": "1->64",
             "children": []
         },
         {
             "type": "html:quotes.simple",
-            "location": "1x65->1x66/64->65",
+            "location": "64->65",
             "children": []
         }
     ]

--- a/test/app/node_modules/modes/html/parser/index/slash-output.json
+++ b/test/app/node_modules/modes/html/parser/index/slash-output.json
@@ -1,5 +1,5 @@
 {
     "type": "html:slash",
-    "location": "1x1->1x2/0->1",
+    "location": "0->1",
     "children": []
 }

--- a/test/app/node_modules/modes/html/parser/index/spaces-output.json
+++ b/test/app/node_modules/modes/html/parser/index/spaces-output.json
@@ -1,6 +1,6 @@
 {
     "type": "html:spaces",
-    "location": "1x1->1x9/0->8",
+    "location": "0->8",
     "children": [],
     "properties": {
         "size": 8

--- a/test/app/node_modules/modes/html/parser/index/tabs-output.json
+++ b/test/app/node_modules/modes/html/parser/index/tabs-output.json
@@ -1,6 +1,6 @@
 {
     "type": "html:tabs",
-    "location": "1x1->1x5/0->4",
+    "location": "0->4",
     "children": [],
     "properties": {
         "size": 4

--- a/test/benchmarks/at-html/index.js
+++ b/test/benchmarks/at-html/index.js
@@ -16,17 +16,17 @@ exports.parsers = [
 exports.inputs = [
 	{name: 'small', source: readSource('small')}
 	,
-	{name: 'medium', source: readSource('medium')} // issue: very long, and three times more with the most efficient parser!!!
+	{name: 'medium', source: readSource('medium')} // issue: very long
 	,
 	{name: '200 lines', source: readSource('200-lines')}
 	,
 	{name: '500 lines', source: readSource('500-lines')}
-	// ,
-	// {name: '1000 lines', source: readSource('1000-lines')} // issue: can't finish
-	// ,
-	// {name: '1000 lines (2)', source: readSource('1000-lines-2')} // issue: can't finish
-	// ,
-	// {name: '1000 lines (3)', source: bigSource = readSource('big')} // issue: can't finish
+	,
+	{name: '1000 lines', source: readSource('1000-lines')} // issue: very long
+	,
+	{name: '1000 lines (2)', source: readSource('1000-lines-2')}
+	,
+	{name: '1000 lines (3)', source: bigSource = readSource('big')} // issue: can't finish
 ];
 
 exports.name = 'AT-HTML';

--- a/test/test.js
+++ b/test/test.js
@@ -198,7 +198,7 @@ describe('Parsers', function(){
 			}, {
 				name: "bracedParamError",
 				rule: "bracedParam",
-				duration: 3,
+				duration: 6,
 				multiple: true,
 				failure: true
 			}, {


### PR DESCRIPTION
# Line and column removal

No more call to line() and column() PEG.js methods are made from the parsers: they were detected as being too expensive.

This implied changing some things in the implementation:
- in the Node class and more generally node module, use of lines and columns have been commented
- in the web application, the annotations put to the editors for validation were using the line and column information: we now use the Ace API to compute them from the index information instead

Tests have also been updated, since the resulting graph doesn't contain anymore the line and column information, so they must be removed from the expected results specifications.
# Node optimization

The Node class is defined using the OOP library, which can provide nice features in terms of API. Unfortunately, one of these features was really expensive, and impacted the construction of the nodes: when you build an average of 20,000 nodes for a HTML file of 1500 lines, the overhead becomes monstruous. However there is a gain even for smaller files, and for every parser since it's related to Node only.

There is now a ligther Node implementation, which modifies only a few things: mainly for node creation, but also for node insertion.

In order not to copy code, a full refactoring has been made:
- there is now a dedicated folder for the whole `node` module
- class definitions have been split into files
- the two nodes implementations share a common base definition for their classes

Finally, and this is something important for this to be used: the NodeInstancier now gets an options at its creation, to choose which node implementation to use.

So now, the grammars use a NodeInstancier instance configured to use the light Node implementation.
# IMPORTANT change in the AT-HTML parser build

Now the AT-HTML parser is built using the PEG.js option `cache` set to `true`. It can make the parser slower as written in the documentation, but it resolved the issue of the parser never finishing parsing some inputs (so what they say in the documentation is true).

Thus I:
- enabled more inputs for benchmarks as now they work, and in acceptable time
- changed a timeout limit in the test of a rule for AT-HTML (maybe slower because if the activated option)
